### PR TITLE
Update symbols.py

### DIFF
--- a/utils/text/symbols.py
+++ b/utils/text/symbols.py
@@ -8,7 +8,7 @@ through Unidecode. For other data, you can modify _characters. See TRAINING_DATA
 from utils.text import cmudict
 
 _pad = '_'
-_eos = '~'
+_eos = ẓ
 _characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!\'(),-.:;? '
 _punctuations = '!\'(),-.:;? '
 _phoneme_punctuations = '.!;:,?'
@@ -16,7 +16,7 @@ _phoneme_punctuations = '.!;:,?'
 # TODO: include more phoneme characters for other languages.
 _phonemes = ['l','ɹ','ɜ','ɚ','k','u','ʔ','ð','ɐ','ɾ','ɑ','ɔ','b','ɛ','t','v','n','m','ʊ','ŋ','s',
              'ʌ','o','ʃ','i','p','æ','e','a','ʒ',' ','h','ɪ','ɡ','f','r','w','ɫ','ɬ','d','x','ː',
-             'ᵻ','ə','j','θ','z','ɒ']
+             'ᵻ','ə','j','θ','z','ɒ','č','ḍ','ǧ','ḥ','ṛ','ṣ','ṭ','ẓ','ɣ']
 
 _phonemes = sorted(list(set(_phonemes)))
 


### PR DESCRIPTION
More phonemes for Kabyle.
Kabyle Alphabet: abcdefghijklmnopqrstuvwxyz + 'č','ḍ','ǧ','ḥ','ṛ','ṣ','ṭ','ẓ','ɣ','ɛ'
Maj: ČḌǦḤṚṢṬẒƔƐ