### PR TITLE
quick fix for multi-speaker

### DIFF
--- a/synthesize.py
+++ b/synthesize.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
 
     # load the model
     num_chars = len(phonemes) if C.use_phonemes else len(symbols)
-    model = setup_model(num_chars, C)
+    model = setup_model(num_chars, num_speakers=0, C)
     cp = torch.load(args.model_path)
     model.load_state_dict(cp['model'])
     model.eval()


### PR DESCRIPTION
`synthesize.py` sends 2 args to `setup_model()`, but 3 are now needed

related to ba8cc8054b87779f78e5cc774f63476b2801df3b AFAIK