### PR TITLE
fixed usage of bos&eos char with caching

### DIFF
--- a/datasets/TTSDataset.py
+++ b/datasets/TTSDataset.py
@@ -99,7 +99,7 @@ class MyDataset(Dataset):
             print(" > ERROR: failed loading phonemes for {}. "
                   "Recomputing.".format(wav_file))
             phonemes = self._generate_and_cache_phoneme_sequence(text,
-                                                                cache_path)
+                                                                 cache_path)
         if self.enable_eos_bos:
             phonemes = pad_with_eos_bos(phonemes)
 

--- a/utils/text/__init__.py
+++ b/utils/text/__init__.py
@@ -4,7 +4,8 @@ import re
 import phonemizer
 from phonemizer.phonemize import phonemize
 from utils.text import cleaners
-from utils.text.symbols import symbols, phonemes, _phoneme_punctuations
+from utils.text.symbols import symbols, phonemes, _phoneme_punctuations, _bos, \
+    _eos
 
 # Mappings from symbol to numeric ID and vice versa:
 _SYMBOL_TO_ID = {s: i for i, s in enumerate(symbols)}
@@ -45,11 +46,12 @@ def text2phone(text, language):
     return ph
 
 
+def pad_with_eos_bos(phoneme_sequence):
+    return [_PHONEMES_TO_ID[_bos]] + phoneme_sequence + [_PHONEMES_TO_ID[_eos]]
+
+
 def phoneme_to_sequence(text, cleaner_names, language, enable_eos_bos=False):
-    if enable_eos_bos:
-        sequence = [_PHONEMES_TO_ID['^']]
-    else:
-        sequence = []
+    sequence = []
     text = text.replace(":", "")
     clean_text = _clean_text(text, cleaner_names)
     to_phonemes = text2phone(clean_text, language)
@@ -60,7 +62,7 @@ def phoneme_to_sequence(text, cleaner_names, language, enable_eos_bos=False):
         sequence += _phoneme_to_sequence(phoneme)
     # Append EOS char
     if enable_eos_bos:
-        sequence.append(_PHONEMES_TO_ID['~'])
+        sequence = pad_with_eos_bos(sequence)
     return sequence
 
 


### PR DESCRIPTION
Previously the caching mechanism effectively overwrote the eos/bos config option. 

1. If a phoneme sequence had been cached without eos/bos, activating it would still give the cached sequence without eos/bos tokens. 
2. vice versa, if a phoneme sequence had been cached with eos/bos, disabling it would still give the cached sequence with eos/bos tokens.

This PR fixes this problem by never caching eos/bos tokens but adding these dynamically based on the config options after restoring the cached sequence.