### PR TITLE
renamed attention_rnn to query_rnn

### DIFF
--- a/layers/common_layers.py
+++ b/layers/common_layers.py
@@ -234,10 +234,10 @@ class Attention(nn.Module):
 
     def forward(self, query, inputs, processed_inputs, mask):
         if self.location_attention:
-            attention, processed_query = self.get_location_attention(
+            attention, _ = self.get_location_attention(
                 query, processed_inputs)
         else:
-            attention, processed_query = self.get_attention(
+            attention, _ = self.get_attention(
                 query, processed_inputs)
         # apply masking
         if mask is not None:

--- a/layers/common_layers.py
+++ b/layers/common_layers.py
@@ -248,13 +248,14 @@ class Attention(nn.Module):
                     dim=1, keepdim=True)
         else:
             raise ValueError("Unknown value for attention norm type")
+
+        if self.location_attention:
+            self.update_location_attention(alignment)
+
         # apply forward attention if enabled
         if self.forward_attn:
             alignment = self.apply_forward_attention(alignment)
             self.alpha = alignment
-
-        if self.location_attention:
-            self.update_location_attention(alignment)
 
         context = torch.bmm(alignment.unsqueeze(1), inputs)
         context = context.squeeze(1)

--- a/layers/common_layers.py
+++ b/layers/common_layers.py
@@ -248,12 +248,13 @@ class Attention(nn.Module):
                     dim=1, keepdim=True)
         else:
             raise ValueError("Unknown value for attention norm type")
-        if self.location_attention:
-            self.update_location_attention(alignment)
         # apply forward attention if enabled
         if self.forward_attn:
             alignment = self.apply_forward_attention(alignment)
             self.alpha = alignment
+
+        if self.location_attention:
+            self.update_location_attention(alignment)
 
         context = torch.bmm(alignment.unsqueeze(1), inputs)
         context = context.squeeze(1)

--- a/layers/tacotron.py
+++ b/layers/tacotron.py
@@ -283,6 +283,7 @@ class Decoder(nn.Module):
         self.memory_size = memory_size if memory_size > 0 else r
         self.memory_dim = memory_dim
         self.separate_stopnet = separate_stopnet
+        self.query_dim = 256
         # memory -> |Prenet| -> processed_memory
         self.prenet = Prenet(
             memory_dim * self.memory_size,
@@ -290,18 +291,18 @@ class Decoder(nn.Module):
             prenet_dropout,
             out_features=[256, 128])
         # processed_inputs, processed_memory -> |Attention| -> Attention, attention, RNN_State
-        self.attention_rnn = nn.GRUCell(in_features + 128, 256)
-        self.attention_layer = Attention(attention_rnn_dim=256,
-                                         embedding_dim=in_features,
-                                         attention_dim=128,
-                                         location_attention=location_attn,
-                                         attention_location_n_filters=32,
-                                         attention_location_kernel_size=31,
-                                         windowing=attn_windowing,
-                                         norm=attn_norm,
-                                         forward_attn=forward_attn,
-                                         trans_agent=trans_agent,
-                                         forward_attn_mask=forward_attn_mask)
+        self.query_rnn = nn.GRUCell(in_features + 128, self.query_dim)
+        self.attention = Attention(query_dim=self.query_dim,
+                                   embedding_dim=in_features,
+                                   attention_dim=128,
+                                   location_attention=location_attn,
+                                   attention_location_n_filters=32,
+                                   attention_location_kernel_size=31,
+                                   windowing=attn_windowing,
+                                   norm=attn_norm,
+                                   forward_attn=forward_attn,
+                                   trans_agent=trans_agent,
+                                   forward_attn_mask=forward_attn_mask)
         # (processed_memory | attention context) -> |Linear| -> decoder_RNN_input
         self.project_to_decoder_in = nn.Linear(256 + in_features, 256)
         # decoder_RNN_input -> |RNN| -> RNN_state
@@ -310,7 +311,7 @@ class Decoder(nn.Module):
         # RNN_state -> |Linear| -> mel_spec
         self.proj_to_mel = nn.Linear(256, memory_dim * r)
         # learn init values instead of zero init.
-        self.attention_rnn_init = nn.Embedding(1, 256)
+        self.query_rnn_init = nn.Embedding(1, 256)
         self.memory_init = nn.Embedding(1, self.memory_size * memory_dim)
         self.decoder_rnn_inits = nn.Embedding(2, 256)
         self.stopnet = StopNet(256 + memory_dim * r)
@@ -347,18 +348,18 @@ class Decoder(nn.Module):
         self.memory_input = self.memory_init(inputs.data.new_zeros(B).long())
 
         # decoder states
-        self.attention_rnn_hidden = self.attention_rnn_init(
+        self.query = self.query_rnn_init(
             inputs.data.new_zeros(B).long())
         self.decoder_rnn_hiddens = [
             self.decoder_rnn_inits(inputs.data.new_tensor([idx] * B).long())
             for idx in range(len(self.decoder_rnns))
         ]
-        self.current_context_vec = inputs.data.new(B, self.in_features).zero_()
+        self.context_vec = inputs.data.new(B, self.in_features).zero_()
         # attention states
         self.attention = inputs.data.new(B, T).zero_()
         self.attention_cum = inputs.data.new(B, T).zero_()
         # cache attention inputs
-        self.processed_inputs = self.attention_layer.inputs_layer(inputs)
+        self.processed_inputs = self.attention.inputs_layer(inputs)
 
     def _parse_outputs(self, outputs, attentions, stop_tokens):
         # Back to batch first
@@ -370,13 +371,15 @@ class Decoder(nn.Module):
     def decode(self, inputs, mask=None):
         # Prenet
         processed_memory = self.prenet(self.memory_input)
+
         # Attention RNN
-        self.attention_rnn_hidden = self.attention_rnn(torch.cat((processed_memory, self.current_context_vec), -1), self.attention_rnn_hidden)
-        self.current_context_vec = self.attention_layer(self.attention_rnn_hidden, inputs, self.processed_inputs, mask)
-        # Concat RNN output and attention context vector
+        self.query = self.query_rnn(torch.cat((processed_memory, self.context_vec), -1), self.query)
+        self.context_vec = self.attention(self.query, inputs, self.processed_inputs, mask)
+
+        # Concat query and attention context vector
         decoder_input = self.project_to_decoder_in(
-            torch.cat((self.attention_rnn_hidden, self.current_context_vec),
-                      -1))
+            torch.cat((self.query, self.context_vec), -1))
+
         # Pass through the decoder RNNs
         for idx in range(len(self.decoder_rnns)):
             self.decoder_rnn_hiddens[idx] = self.decoder_rnns[idx](
@@ -384,18 +387,18 @@ class Decoder(nn.Module):
             # Residual connection
             decoder_input = self.decoder_rnn_hiddens[idx] + decoder_input
         decoder_output = decoder_input
-        del decoder_input
+
         # predict mel vectors from decoder vectors
         output = self.proj_to_mel(decoder_output)
         output = torch.sigmoid(output)
+
         # predict stop token
         stopnet_input = torch.cat([decoder_output, output], -1)
-        del decoder_output
         if self.separate_stopnet:
             stop_token = self.stopnet(stopnet_input.detach())
         else:
             stop_token = self.stopnet(stopnet_input)
-        return output, stop_token, self.attention_layer.attention_weights
+        return output, stop_token, self.attention.attention_weights
 
     def _update_memory_queue(self, new_memory):
         if self.memory_size > 0 and new_memory.shape[-1] < self.memory_size:
@@ -427,7 +430,7 @@ class Decoder(nn.Module):
         stop_tokens = []
         t = 0
         self._init_states(inputs)
-        self.attention_layer.init_states(inputs)
+        self.attention.init_states(inputs)
         while len(outputs) < memory.size(0):
             if t > 0:
                 new_memory = memory[t - 1]
@@ -453,8 +456,8 @@ class Decoder(nn.Module):
         stop_tokens = []
         t = 0
         self._init_states(inputs)
-        self.attention_layer.init_win_idx()
-        self.attention_layer.init_states(inputs)
+        self.attention.init_win_idx()
+        self.attention.init_states(inputs)
         while True:
             if t > 0:
                 new_memory = outputs[-1]

--- a/layers/tacotron.py
+++ b/layers/tacotron.py
@@ -355,9 +355,6 @@ class Decoder(nn.Module):
             for idx in range(len(self.decoder_rnns))
         ]
         self.context_vec = inputs.data.new(B, self.in_features).zero_()
-        # attention states
-        self.attention = inputs.data.new(B, T).zero_()
-        self.attention_cum = inputs.data.new(B, T).zero_()
         # cache attention inputs
         self.processed_inputs = self.attention.inputs_layer(inputs)
 


### PR DESCRIPTION
I renamed attention_rnn in Taco1 and Taco2 decoders to query_rnn to avoid the confusion with the attention layer. At least personally I had my head spinning distinguishing attention_rnn, attention_rnn_hidden, attention_layer, attention, etc.  

I think this naming change makes more clear that there is a part generating the query and then the attention part that uses the query. Especially since `attention_rnn_hidden` turned to `query` inside the attention layer at some point already.

Other changes that you should specifically look at:
1. In forward attention: moved the to_device to directly after the cloning, not after padding
2. in forward attention: removed the cloning where the alpha tensor is just multiplied with the u tensor
3. in tacotron - decoder - decode: removed the del statements. I believe this is not saving memory since a) you just created another reference beforehand without cloning, and b) the tensors have to be kept around for back prop. Also, invoking the garbage collector inside the training loop might cost performance