### PR TITLE
generic phoneme cleaners

### DIFF
--- a/utils/text/cleaners.py
+++ b/utils/text/cleaners.py
@@ -88,10 +88,15 @@ def english_cleaners(text):
     return text
 
 
-def phoneme_cleaners(text):
+def phoneme_cleaners_en(text):
     '''Pipeline for phonemes mode, including number and abbreviation expansion.'''
     text = convert_to_ascii(text)
     text = expand_numbers(text)
     text = expand_abbreviations(text)
+    text = collapse_whitespace(text)
+    return text
+  
+  
+def phoneme_cleaners(text):
     text = collapse_whitespace(text)
     return text


### PR DESCRIPTION
The original `phoneme_cleaners` are not suited for German (or languages other than English) at all. For example, they remove German umlauts and replace numbers with their english equivalents. Since we are using espeak which is doing good work with the normalization already,  `phoneme_cleaners` shouldn't be doing much work. The specialized English version (now `phoneme_cleaners_en`) should have a better name to avoid confusion.

This change invalidates phoneme caches.