### PR TITLE
fix normalization min val

### DIFF
--- a/utils/audio.py
+++ b/utils/audio.py
@@ -79,7 +79,7 @@ class AudioProcessor(object):
         if self.signal_norm:
             min_val = np.min(S)
             val_range = np.max(S) - min_val
-            S_norm = ((S - min_val) / - val_range)
+            S_norm = ((S - min_val) / val_range)
             if self.symmetric_norm:
                 S_norm = ((2 * self.max_norm) * S_norm) - self.max_norm
                 if self.clip_norm:

--- a/utils/audio.py
+++ b/utils/audio.py
@@ -78,7 +78,8 @@ class AudioProcessor(object):
         #pylint: disable=no-else-return
         if self.signal_norm:
             min_val = self.min_level_db - self.ref_level_db
-            S_norm = ((S - min_val) / - min_val)
+            val_range = self.min_level_db 
+            S_norm = ((S - min_val) / - val_range)
             if self.symmetric_norm:
                 S_norm = ((2 * self.max_norm) * S_norm) - self.max_norm
                 if self.clip_norm:

--- a/utils/audio.py
+++ b/utils/audio.py
@@ -77,8 +77,8 @@ class AudioProcessor(object):
         """Put values in [0, self.max_norm] or [-self.max_norm, self.max_norm]"""
         #pylint: disable=no-else-return
         if self.signal_norm:
-            min_val = self.min_level_db - self.ref_level_db
-            val_range = self.min_level_db 
+            min_val = np.min(S)
+            val_range = np.max(S) - min_val
             S_norm = ((S - min_val) / - val_range)
             if self.symmetric_norm:
                 S_norm = ((2 * self.max_norm) * S_norm) - self.max_norm

--- a/utils/audio.py
+++ b/utils/audio.py
@@ -77,7 +77,8 @@ class AudioProcessor(object):
         """Put values in [0, self.max_norm] or [-self.max_norm, self.max_norm]"""
         #pylint: disable=no-else-return
         if self.signal_norm:
-            S_norm = ((S - self.min_level_db) / - self.min_level_db)
+            min_val = self.min_level_db - self.ref_level_db
+            S_norm = ((S - min_val) / - min_val)
             if self.symmetric_norm:
                 S_norm = ((2 * self.max_norm) * S_norm) - self.max_norm
                 if self.clip_norm:

--- a/utils/audio.py
+++ b/utils/audio.py
@@ -77,9 +77,9 @@ class AudioProcessor(object):
         """Put values in [0, self.max_norm] or [-self.max_norm, self.max_norm]"""
         #pylint: disable=no-else-return
         if self.signal_norm:
-            min_val = np.min(S)
-            val_range = np.max(S) - min_val
-            S_norm = ((S - min_val) / val_range)
+            min_val = self.min_level_db - self.ref_level_db
+            val_range = self.min_level_db
+            S_norm = ((S - min_val) / -val_range)
             if self.symmetric_norm:
                 S_norm = ((2 * self.max_norm) * S_norm) - self.max_norm
                 if self.clip_norm:


### PR DESCRIPTION
spectrogram normalization was using the wrong minimum value. In both linear- and mel spec generation `ref_level_db` is subtracted before normalizing, moving the lowest value - coming from `amp_to_db` and `min_level_db` - even lower. The result of this error is that either the spec is not properly normalized (e.g. interval `[-0.2, 1.0]` for `min_level_db=100` and `ref_level_db=20` instead of `[0,1]`, or clipping to interval `[0,1]` removes resolution of values.