### PR TITLE
Fixed postnet for GST.

### DIFF
--- a/models/tacotrongst.py
+++ b/models/tacotrongst.py
@@ -38,9 +38,8 @@ class TacotronGST(nn.Module):
                                forward_attn, trans_agent, forward_attn_mask,
                                location_attn, separate_stopnet)
         self.postnet = PostCBHG(mel_dim)
-        self.last_linear = nn.Sequential(
-            nn.Linear(self.postnet.cbhg.gru_features * 2, linear_dim),
-            nn.Sigmoid())
+        self.last_linear = nn.Linear(self.postnet.cbhg.gru_features * 2, linear_dim)
+        
 
     def forward(self, characters, text_lengths, mel_specs, speaker_ids=None):
         B = characters.size(0)


### PR DESCRIPTION
GST model was applying sigmoid to the output of the postnet. This doesn't match regular tacotron model. Sound generated by the GST branch was all wrong because of the extra sigmoid applied. 