### PR TITLE
Use direct link for specifying phonemizer dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,8 +81,6 @@ setup(
         # "lws",
         "tqdm",
         "soundfile",
-    ],
-    dependency_links=[
-        'http://github.com/bootphon/phonemizer/tarball/master#egg=phonemizer'
+        "phonemizer @ https://github.com/bootphon/phonemizer/tarball/master",
     ],
 )


### PR DESCRIPTION
Seems like dependency_links is broken due to https://xkcd.com/927/

This solution works for a cloned folder but not if you publish to PyPi, so we would need a better solution if we wanted to publish TTS.