### PR TITLE
Fix vocoder normalization when no vocoder is used

### DIFF
--- a/synthesize.py
+++ b/synthesize.py
@@ -1,3 +1,4 @@
+# pylint: disable=redefined-outer-name, unused-argument
 import os
 import time
 import argparse
@@ -30,9 +31,9 @@ def tts(model,
     if C.model == "Tacotron" and use_vocoder_model:
         postnet_output = ap.out_linear_to_mel(postnet_output.T).T
     # correct if there is a scale difference b/w two models
-    postnet_output = ap._denormalize(postnet_output) # pylint: disable=W021
+    postnet_output = ap._denormalize(postnet_output) # pylint: disable=protected-access
     if use_vocoder_model:
-        postnet_output = ap_vocoder._normalize(postnet_output) # pylint: disable=W021
+        postnet_output = ap_vocoder._normalize(postnet_output) # pylint: disable=protected-access
         vocoder_input = torch.FloatTensor(postnet_output.T).unsqueeze(0)
         waveform = vocoder_model.generate(
             vocoder_input.cuda() if use_cuda else vocoder_input,

--- a/synthesize.py
+++ b/synthesize.py
@@ -30,9 +30,9 @@ def tts(model,
     if C.model == "Tacotron" and use_vocoder_model:
         postnet_output = ap.out_linear_to_mel(postnet_output.T).T
     # correct if there is a scale difference b/w two models
-    postnet_output = ap._denormalize(postnet_output)
+    postnet_output = ap._denormalize(postnet_output) # pylint: disable=W021
     if use_vocoder_model:
-        postnet_output = ap_vocoder._normalize(postnet_output)
+        postnet_output = ap_vocoder._normalize(postnet_output) # pylint: disable=W021
         vocoder_input = torch.FloatTensor(postnet_output.T).unsqueeze(0)
         waveform = vocoder_model.generate(
             vocoder_input.cuda() if use_cuda else vocoder_input,

--- a/synthesize.py
+++ b/synthesize.py
@@ -31,8 +31,8 @@ def tts(model,
         postnet_output = ap.out_linear_to_mel(postnet_output.T).T
     # correct if there is a scale difference b/w two models
     postnet_output = ap._denormalize(postnet_output)
-    postnet_output = ap_vocoder._normalize(postnet_output)
     if use_vocoder_model:
+        postnet_output = ap_vocoder._normalize(postnet_output)
         vocoder_input = torch.FloatTensor(postnet_output.T).unsqueeze(0)
         waveform = vocoder_model.generate(
             vocoder_input.cuda() if use_cuda else vocoder_input,


### PR DESCRIPTION
When G&L is used, ap_vocoder is None and crashes