### PR TITLE
Restore regular command line capability

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -61,5 +61,6 @@ if __name__ == '__main__':
     # is present.
     if not config or not synthesizer or args.tts_checkpoint or args.tts_config:
         synthesizer = Synthesizer(args)
+        config = args
 
     app.run(debug=config.debug, host='0.0.0.0', port=config.port)


### PR DESCRIPTION
Recent changes to use server.py appear to have broken the ability to run it from the command line. This change should (I believe) restore that ability, whilst (I hope) not interfering with usage for people who have installed a model package.