### PR TITLE
Small fix for "Tacotron" use

### DIFF
--- a/train.py
+++ b/train.py
@@ -47,7 +47,7 @@ def setup_loader(ap, r, is_val=False, verbose=False):
         dataset = MyDataset(
             r,
             c.text_cleaner,
-            compute_linear_spec=True if c.model.lower() is 'tacotron' else False,
+            compute_linear_spec=True if c.model in ["Tacotron"] else False,
             meta_data=meta_data_eval if is_val else meta_data_train,
             ap=ap,
             tp=c.characters if 'characters' in c.keys() else None,


### PR DESCRIPTION
"Tacotron" won't work without this fix, since the linear spectrograms end up not getting computed