### PR TITLE
Configurable number of workers for DataLoader

### DIFF
--- a/speaker_encoder/config.json
+++ b/speaker_encoder/config.json
@@ -34,6 +34,7 @@
     "save_step": 1000, // Number of training steps expected to save traning stats and checkpoints.
     "print_step": 1, // Number of steps to log traning on console.
     "output_path": "/media/erogol/data_ssd/Models/libri_tts/speaker_encoder/", // DATASET-RELATED: output path for all training outputs.
+    "num_loader_workers": 0, // number of training data loader processes. Don't set it too big. 4-8 are good values.
     "model": {
         "input_dim": 40,
         "proj_dim": 128,

--- a/speaker_encoder/train.py
+++ b/speaker_encoder/train.py
@@ -44,7 +44,7 @@ def setup_loader(ap, is_val=False, verbose=False):
         loader = DataLoader(dataset,
                             batch_size=c.num_speakers_in_batch,
                             shuffle=False,
-                            num_workers=0,
+                            num_workers=c.num_loader_workers,
                             collate_fn=dataset.collate_fn)
     return loader
 


### PR DESCRIPTION
As discussed [here](https://discourse.mozilla.org/t/update-released-speaker-encoder/47903/2), training the Speaker Encoder is rather slow, with the `DataLoader` being the bottleneck. This PR allows to set the number of workers of the `DataLoader` via the respective `config.json`. 