### PR TITLE
Improve runtime of __parse_items(), +1

### DIFF
--- a/speaker_encoder/dataset.py
+++ b/speaker_encoder/dataset.py
@@ -65,7 +65,7 @@ class MyDataset(Dataset):
 
         if self.skip_speakers:
             self.speaker_to_utters = {k: v for (k, v) in self.speaker_to_utters.items() if
-                                      len(v) >= self.num_utter_per_speaker or not self.skip_speakers}
+                                      len(v) >= self.num_utter_per_speaker}
 
         self.speakers = [k for (k, v) in self.speaker_to_utters]
 

--- a/speaker_encoder/dataset.py
+++ b/speaker_encoder/dataset.py
@@ -54,18 +54,20 @@ class MyDataset(Dataset):
         """
         Find unique speaker ids and create a dict mapping utterances from speaker id
         """
-        speakers = list({item[-1] for item in self.items})
         self.speaker_to_utters = {}
-        self.speakers = []
-        for speaker in speakers:
-            speaker_utters = [item[1] for item in self.items if item[2] == speaker]
-            if len(speaker_utters) < self.num_utter_per_speaker and self.skip_speakers:
-                print(
-                    f" [!] Skipped speaker {speaker}. Not enough utterances {self.num_utter_per_speaker} vs {len(speaker_utters)}."
-                )
+        for i in self.items:
+            path_ = i[1]
+            speaker_ = i[2]
+            if speaker_ in self.speaker_to_utters.keys():
+                self.speaker_to_utters[speaker_].append(path_)
             else:
-                self.speakers.append(speaker)
-                self.speaker_to_utters[speaker] = speaker_utters
+                self.speaker_to_utters[speaker_] = [path_, ]
+
+        if self.skip_speakers:
+            self.speaker_to_utters = {k: v for (k, v) in self.speaker_to_utters.items() if
+                                      len(v) >= self.num_utter_per_speaker or not self.skip_speakers}
+
+        self.speakers = [k for (k, v) in self.speaker_to_utters]
 
     def __len__(self):
         return int(1e10)

--- a/speaker_encoder/model.py
+++ b/speaker_encoder/model.py
@@ -84,5 +84,5 @@ class SpeakerEncoder(nn.Module):
                 embed[cur_iter <= num_iters, :] += self.inference(
                     frames[cur_iter <= num_iters, :, :]
                 )
-        return embed / num_iters
+        return embed / num_iters.unsqueeze(-1)
 


### PR DESCRIPTION
Two small changes:
1) Improve runtime of __parse_items() from O(|speakers|*|items|) to O(|items|)
2) Small fix in batch_compute_embedding, where divisor was in incorrect format (was shape [32], should be shape [32, 1])