### PR TITLE
Fix "TypeError: The argument is not a tensor" when training

### DIFF
--- a/utils/training.py
+++ b/utils/training.py
@@ -9,7 +9,7 @@ def check_update(model, grad_clip, ignore_stopnet=False):
         grad_norm = torch.nn.utils.clip_grad_norm_([param for name, param in model.named_parameters() if 'stopnet' not in name], grad_clip)
     else:
         grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), grad_clip)
-    if torch.isinf(grad_norm):
+    if np.isinf(grad_norm):
         print(" | > Gradient is INF !!")
         skip_flag = True
     return grad_norm, skip_flag


### PR DESCRIPTION
As mentioned in this comment: https://gist.github.com/erogol/97516ad65b44dbddb8cd694953187c5b

When following the colab example we see `TypeError: The argument is not a tensor`

Looks like this slipped in a couple days ago here: https://github.com/mozilla/TTS/commit/dc166b42e37a20ab950c3d39cfacb33444dca102