### PR TITLE
Fix phoneme cache file name aliasing problem

### DIFF
--- a/datasets/TTSDataset.py
+++ b/datasets/TTSDataset.py
@@ -92,7 +92,7 @@ class MyDataset(Dataset):
         return phonemes
 
     def _load_or_generate_phoneme_sequence(self, wav_file, text):
-        file_name = os.path.basename(wav_file).split('.')[0]
+        file_name = os.path.splitext(os.path.basename(wav_file))[0]
         cache_path = os.path.join(self.phoneme_cache_path,
                                   file_name + '_phoneme.npy')
         try:


### PR DESCRIPTION
When the wav file has multiple dots in the file name,
_load_or_generate_phoneme_sequence would only use only the first segment
of the file name and cause overwrite (or not generate) of *_phoneme.npy