### PR TITLE
Fixed Import

### DIFF
--- a/notebooks/CheckSpectrograms.ipynb
+++ b/notebooks/CheckSpectrograms.ipynb
@@ -18,7 +18,7 @@
     "%matplotlib inline\n",
     "from TTS.utils.audio import AudioProcessor\n",
     "from TTS.utils.visual import plot_spectrogram\n",
-    "from TTS.utils.generic_utils import load_config\n",
+    "from TTS.utils.io import load_config\n",
     "import glob \n",
     "import IPython.display as ipd"
    ]


### PR DESCRIPTION
`load_config` is incorrectly imported from `TTS.utils.generic_utils` instead of `TTS.utils.io`.