### PR TITLE
Add a language_switch='remove-flags' argument when calling phonemize

### DIFF
--- a/mozilla_voice_tts/tts/utils/text/__init__.py
+++ b/mozilla_voice_tts/tts/utils/text/__init__.py
@@ -45,7 +45,7 @@ def text2phone(text, language):
                 for punct in punctuations:
                     ph = ph.replace('| |\n', '|'+punct+'| |', 1)
     elif version.parse(phonemizer.__version__) >= version.parse('2.1'):
-        ph = phonemize(text, separator=seperator, strip=False, njobs=1, backend='espeak', language=language, preserve_punctuation=True)
+        ph = phonemize(text, separator=seperator, strip=False, njobs=1, backend='espeak', language=language, preserve_punctuation=True, language_switch='remove-flags')
         # this is a simple fix for phonemizer.
         # https://github.com/bootphon/phonemizer/issues/32
         if punctuations:


### PR DESCRIPTION
Hi

I'm trying out the Japanese voice training, referring to [TTS_recipes](https://github.com/erogol/TTS_recipes/blob/master/Thorsten_DE/DoubleDecoderConsistency/train_model.sh).

Along the way, I realized that the phonemize's language_switch defaults to ```keep-flags```, but I just think that data containing the flags can be noisy.
Would it matter if I modified it to add ```remove-flags``` as shown below?

sample:
```
import phonemizer
from phonemizer.phonemize import phonemize
seperator = phonemizer.separator.Separator(' |', '', '|')

# AS IS
ph = phonemize('こんにちは. OK.', separator=seperator, strip=False, njobs=1, backend='espeak', language='ja', preserve_punctuation=True)
print("こんにちは. OK. (keep-flags)\t" + ph)

# TO BE
ph = phonemize('こんにちは. OK.', separator=seperator, strip=False, njobs=1, backend='espeak', language='ja', preserve_punctuation=True, language_switch='remove-flags')
print("こんにちは. OK. (remove-flags)\t" + ph)
```

result:
```
こんにちは. OK. (keep-flags)	k|o̞|n|n|i|tɕ|i|h|ä| |. |(en)|əʊ| ||k|eɪ|(ja)| |.
こんにちは. OK. (remove-flags)	k|o̞|n|n|i|tɕ|i|h|ä| |. ||əʊ| ||k|eɪ|| |.
```