### PR TITLE
use difflib for string matching

### DIFF
--- a/TTS/bin/convert_melgan_torch_to_tf.py
+++ b/TTS/bin/convert_melgan_torch_to_tf.py
@@ -1,10 +1,10 @@
 import argparse
+from difflib import SequenceMatcher
 import os
 
 import numpy as np
 import tensorflow as tf
 import torch
-from fuzzywuzzy import fuzz
 
 from TTS.utils.io import load_config
 from TTS.vocoder.tf.utils.convert_torch_to_tf_utils import (
@@ -67,7 +67,7 @@ for tf_name in tf_var_names:
         continue
     tf_name_edited = convert_tf_name(tf_name)
     ratios = [
-        fuzz.ratio(torch_name, tf_name_edited)
+        SequenceMatcher(None, torch_name, tf_name_edited).ratio()
         for torch_name in torch_var_names
     ]
     max_idx = np.argmax(ratios)

--- a/TTS/bin/convert_tacotron2_torch_to_tf.py
+++ b/TTS/bin/convert_tacotron2_torch_to_tf.py
@@ -1,6 +1,7 @@
 # %%
 # %%
 import argparse
+from difflib import SequenceMatcher
 import os
 import sys
 # %%
@@ -10,7 +11,6 @@ from pprint import pprint
 import numpy as np
 import tensorflow as tf
 import torch
-from fuzzywuzzy import fuzz
 from TTS.tts.tf.models.tacotron2 import Tacotron2
 from TTS.tts.tf.utils.convert_torch_to_tf_utils import (
     compare_torch_tf, convert_tf_name, transfer_weights_torch_to_tf)
@@ -106,7 +106,7 @@ for tf_name in tf_var_names:
         continue
     tf_name_edited = convert_tf_name(tf_name)
     ratios = [
-        fuzz.ratio(torch_name, tf_name_edited)
+        SequenceMatcher(None, torch_name, tf_name_edited).ratio()
         for torch_name in torch_var_names
     ]
     max_idx = np.argmax(ratios)

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,4 @@ soundfile
 nose==1.3.7
 cardboardlint==1.3.0
 pylint==2.5.3
-fuzzywuzzy
 gdown


### PR DESCRIPTION
When using the slower version of FuzzyWuzzy it is using difflib internally, so there is not really a need to add a GPL licensed dependency for this. (When better performance is required [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) is a faster alternative to Fuzzywuzzy, thats MIT Licensed aswell)