### PR TITLE
Fix import to grab the encoder model save function

### DIFF
--- a/TTS/bin/train_encoder.py
+++ b/TTS/bin/train_encoder.py
@@ -13,10 +13,9 @@ from TTS.speaker_encoder.dataset import MyDataset
 from TTS.speaker_encoder.losses import AngleProtoLoss, GE2ELoss
 from TTS.speaker_encoder.model import SpeakerEncoder
 from TTS.speaker_encoder.utils.generic_utils import \
-    check_config_speaker_encoder
+    check_config_speaker_encoder, save_best_model
 from TTS.speaker_encoder.utils.visual import plot_embeddings
 from TTS.tts.datasets.preprocess import load_meta_data
-from TTS.tts.utils.io import save_best_model
 from TTS.utils.audio import AudioProcessor
 from TTS.utils.generic_utils import (count_parameters,
                                      create_experiment_folder, get_git_branch,


### PR DESCRIPTION
I saw that this was recently changed but I'm not sure if it should have been. This is the correct function given the arguments provided to it in the train loop. Should the arguments be updated to reflect the new model save function or should the import be reverted? I am currently running a model training with the old save function and things appear to work fine.