### PR TITLE
requirements.txt: Install correct umap-learn library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,5 +21,5 @@ nose==1.3.7
 cardboardlint==1.3.0
 pylint==2.5.3
 gdown
-umap
+umap-learn
 cython


### PR DESCRIPTION
There is a name clash among several umap projects and the wrong umap has
been introduced into requirements.txt.

Ref: https://github.com/koorukuroo/umap/issues/1