### PR TITLE
Increase robustness in synthesize with wavegrad model

### DIFF
--- a/TTS/bin/synthesize.py
+++ b/TTS/bin/synthesize.py
@@ -37,7 +37,8 @@ def tts(model, vocoder_model, text, CONFIG, use_cuda, ap, use_gl, speaker_fileid
     if CONFIG.model == "Tacotron" and not use_gl:
         mel_postnet_spec = ap.out_linear_to_mel(mel_postnet_spec.T).T
     if not use_gl:
-        waveform = vocoder_model.inference(torch.FloatTensor(mel_postnet_spec.T).unsqueeze(0))
+        device_type = "cuda" if use_cuda else "cpu"
+        waveform = vocoder_model.inference(torch.FloatTensor(mel_postnet_spec.T).to(device_type).unsqueeze(0))
     if use_cuda and not use_gl:
         waveform = waveform.cpu()
     if not use_gl:

--- a/TTS/bin/synthesize.py
+++ b/TTS/bin/synthesize.py
@@ -37,8 +37,13 @@ def tts(model, vocoder_model, text, CONFIG, use_cuda, ap, use_gl, speaker_fileid
     if CONFIG.model == "Tacotron" and not use_gl:
         mel_postnet_spec = ap.out_linear_to_mel(mel_postnet_spec.T).T
     if not use_gl:
+        # Use if not computed noise schedule with tune_wavegrad
         beta = np.linspace(1e-6, 0.01, 50)
         vocoder_model.compute_noise_level(beta)
+
+        # Use alternative when using output npy file from tune_wavegrad
+        # beta = np.load("output-tune-wavegrad.npy", allow_pickle=True).item()
+        # vocoder_model.compute_noise_level(beta['beta'])
         
         device_type = "cuda" if use_cuda else "cpu"
         waveform = vocoder_model.inference(torch.FloatTensor(mel_postnet_spec.T).to(device_type).unsqueeze(0))

--- a/TTS/bin/synthesize.py
+++ b/TTS/bin/synthesize.py
@@ -37,6 +37,9 @@ def tts(model, vocoder_model, text, CONFIG, use_cuda, ap, use_gl, speaker_fileid
     if CONFIG.model == "Tacotron" and not use_gl:
         mel_postnet_spec = ap.out_linear_to_mel(mel_postnet_spec.T).T
     if not use_gl:
+        beta = np.linspace(1e-6, 0.01, 50)
+        vocoder_model.compute_noise_level(beta)
+        
         device_type = "cuda" if use_cuda else "cpu"
         waveform = vocoder_model.inference(torch.FloatTensor(mel_postnet_spec.T).to(device_type).unsqueeze(0))
     if use_cuda and not use_gl:


### PR DESCRIPTION
I didn't succeed on running synthesize.py with my wavegrad model. But @SanjaESC did an amazing job and helped me out with the right code adjustments. With his nice permission, i can create this PR.

It increases the robustness for following issues:

* AttributeError: 'NoneType' object has no attribute 'to'
* RuntimeError: Expected object of device type cuda but got device type cpu for argument #1 'self' in call to _thnn_conv2d_forward
* Added codesnipplet when using computed npy file from tune-wavegrad

Thanks @SanjaESC 🥇