### PR TITLE
Update train_tacotron.py

### DIFF
--- a/TTS/bin/train_tacotron.py
+++ b/TTS/bin/train_tacotron.py
@@ -549,7 +549,7 @@ def main(args):  # pylint: disable=redefined-outer-name
                 scaler.load_state_dict(checkpoint["scaler"])
             if c.reinit_layers:
                 raise RuntimeError
-        except KeyError:
+        except (KeyError, RuntimeError):
             print(" > Partial model initialization.")
             model_dict = model.state_dict()
             model_dict = set_init_dict(model_dict, checkpoint['model'], c)


### PR DESCRIPTION
When attempting to fine-tune a model with `"prenet_type": "bn"` that was originally trained with `"prenet_type": "original"`, a `RuntimeError` is thrown that stops the training.

By catching the `RuntimeError`, the required layers can be partially restored and the training will continue without any problems.