### PR TITLE
update static stopnet_pos_weight parameter

### DIFF
--- a/TTS/bin/train_tacotron.py
+++ b/TTS/bin/train_tacotron.py
@@ -534,7 +534,7 @@ def main(args):  # pylint: disable=redefined-outer-name
         optimizer_st = None
 
     # setup criterion
-    criterion = TacotronLoss(c, stopnet_pos_weight=10.0, ga_sigma=0.4)
+    criterion = TacotronLoss(c, stopnet_pos_weight=c.stopnet_pos_weight, ga_sigma=0.4)
 
     if args.restore_path:
         checkpoint = torch.load(args.restore_path, map_location='cpu')


### PR DESCRIPTION
config parameter `c.stopnet_pos_weight` currently has no effect as it is not used.

I suppose it could be passed as a parameter as proposed.
Or similar to other parameters read from config in losses.py