### PR TITLE
Fix greedy substitution in read_json_with_comments

### DIFF
--- a/TTS/utils/io.py
+++ b/TTS/utils/io.py
@@ -26,7 +26,7 @@ def read_json_with_comments(json_path):
         input_str = f.read()
     # handle comments
     input_str = re.sub(r'\\\n', '', input_str)
-    input_str = re.sub(r'//.*\n', '\n', input_str)
+    input_str = re.sub(r'^\s+//.*\n', '\n', input_str)
     data = json.loads(input_str)
     return data
 


### PR DESCRIPTION
The substitution tries to match comments like this:

```
  // this is a comment
```

but accidentally also matched

```
  "url": "tcp://localhost:54321",
```

and transformed it into

```
  "url": "tcp:
```

which in turn broke the JSON import.

Fix this by making sure the substitution only happens when the comment
starts at the beginning of a line or only has white spaces preceeding
it.

Fixes: #631