### PR TITLE
Set out_path to be required param in compute_statistics.py.

### DIFF
--- a/TTS/bin/compute_statistics.py
+++ b/TTS/bin/compute_statistics.py
@@ -19,8 +19,8 @@ def main():
         description="Compute mean and variance of spectrogtram features.")
     parser.add_argument("--config_path", type=str, required=True,
                         help="TTS config file path to define audio processin parameters.")
-    parser.add_argument("--out_path", default=None, type=str,
-                        help="directory to save the output file.")
+    parser.add_argument("--out_path", type=str, required=True
+                        help="save path (directory and filename).")
     args = parser.parse_args()
 
     # load config


### PR DESCRIPTION
Fix for following issue:

When running compute_statistics.py with configfile param, but without out_path compution is running for 100% and throws an io exception afterwards, because of missing out_path.

Set out_path as required arg.

 > Avg mel spec mean: -2.5096506414089936
 > Avg mel spec scale: 0.8145479622630323
 > Avg linear spec mean: -1.8196869894752261
 > Avg lienar spec scale: 0.7276981902559411
Traceback (most recent call last):
  File "./compute_statistics.py", line 90, in <module>
    main()
  File "./compute_statistics.py", line 85, in main
    np.save(output_file_path, stats, allow_pickle=True)
  File "<__array_function__ internals>", line 6, in save
  File "/home/thorsten/___prj/tts/models/taco2/lib/python3.6/site-packages/numpy/lib/npyio.py", line 538, in save
    file = os_fspath(file)
TypeError: expected str, bytes or os.PathLike object, not NoneType
