### PR TITLE
restructured arg parsing and processing to utils

### DIFF
--- a/TTS/bin/train_glow_tts.py
+++ b/TTS/bin/train_glow_tts.py
@@ -552,7 +552,7 @@ def main(args):  # pylint: disable=redefined-outer-name
         train_avg_loss_dict, global_step = train(train_loader, model, criterion, optimizer,
                                                  scheduler, ap, global_step,
                                                  epoch)
-        eval_avg_loss_dict = evaluate(eval_loader , model, criterion, ap,
+        eval_avg_loss_dict = evaluate(eval_loader, model, criterion, ap,
                                       global_step, epoch)
         c_logger.print_epoch_end(epoch, eval_avg_loss_dict)
         target_loss = train_avg_loss_dict['avg_loss']

--- a/TTS/bin/train_glow_tts.py
+++ b/TTS/bin/train_glow_tts.py
@@ -116,7 +116,7 @@ def format_data(data):
          avg_text_length, avg_spec_length, attn_mask, item_idx
 
 
-def data_depended_init(data_loader, model, ap):
+def data_depended_init(data_loader, model):
     """Data depended initialization for activation normalization."""
     if hasattr(model, 'module'):
         for f in model.module.decoder.flows:
@@ -135,7 +135,7 @@ def data_depended_init(data_loader, model, ap):
 
             # format data
             text_input, text_lengths, mel_input, mel_lengths, spekaer_embed,\
-                _, _, attn_mask, item_idx = format_data(data)
+                _, _, attn_mask, _ = format_data(data)
 
             # forward pass model
             _ = model.forward(
@@ -174,7 +174,7 @@ def train(data_loader, model, criterion, optimizer, scheduler,
 
         # format data
         text_input, text_lengths, mel_input, mel_lengths, speaker_c,\
-            avg_text_length, avg_spec_length, attn_mask, item_idx = format_data(data)
+            avg_text_length, avg_spec_length, attn_mask, _ = format_data(data)
 
         loader_time = time.time() - end_time
 
@@ -188,20 +188,20 @@ def train(data_loader, model, criterion, optimizer, scheduler,
 
             # compute loss
             loss_dict = criterion(z, y_mean, y_log_scale, logdet, mel_lengths,
-                                o_dur_log, o_total_dur, text_lengths)
+                                  o_dur_log, o_total_dur, text_lengths)
 
         # backward pass with loss scaling
         if c.mixed_precision:
             scaler.scale(loss_dict['loss']).backward()
             scaler.unscale_(optimizer)
             grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(),
-                                           c.grad_clip)
+                                                       c.grad_clip)
             scaler.step(optimizer)
             scaler.update()
         else:
             loss_dict['loss'].backward()
             grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(),
-                                           c.grad_clip)
+                                                       c.grad_clip)
             optimizer.step()
 
         # setup lr
@@ -329,7 +329,7 @@ def evaluate(data_loader, model, criterion, ap, global_step, epoch):
 
             # format data
             text_input, text_lengths, mel_input, mel_lengths, speaker_c,\
-                _, _, attn_mask, item_idx = format_data(data)
+                _, _, attn_mask, _ = format_data(data)
 
             # forward pass model
             z, logdet, y_mean, y_log_scale, alignments, o_dur_log, o_total_dur = model.forward(
@@ -546,13 +546,14 @@ def main(args):  # pylint: disable=redefined-outer-name
     eval_loader = setup_loader(ap, 1, is_val=True, verbose=True)
 
     global_step = args.restore_step
-    model = data_depended_init(train_loader, model, ap)
+    model = data_depended_init(train_loader, model)
     for epoch in range(0, c.epochs):
         c_logger.print_epoch_start(epoch, c.epochs)
         train_avg_loss_dict, global_step = train(train_loader, model, criterion, optimizer,
                                                  scheduler, ap, global_step,
                                                  epoch)
-        eval_avg_loss_dict = evaluate(eval_loader , model, criterion, ap, global_step, epoch)
+        eval_avg_loss_dict = evaluate(eval_loader , model, criterion, ap,
+                                      global_step, epoch)
         c_logger.print_epoch_end(epoch, eval_avg_loss_dict)
         target_loss = train_avg_loss_dict['avg_loss']
         if c.run_eval:

--- a/TTS/bin/train_speedy_speech.py
+++ b/TTS/bin/train_speedy_speech.py
@@ -11,6 +11,7 @@ import numpy as np
 from random import randrange
 
 import torch
+from TTS.utils.arguments import parse_arguments, process_args
 # DISTRIBUTED
 from torch.nn.parallel import DistributedDataParallel as DDP_th
 from torch.utils.data import DataLoader
@@ -18,7 +19,7 @@ from torch.utils.data.distributed import DistributedSampler
 from TTS.tts.datasets.preprocess import load_meta_data
 from TTS.tts.datasets.TTSDataset import MyDataset
 from TTS.tts.layers.losses import SpeedySpeechLoss
-from TTS.tts.utils.generic_utils import check_config_tts, setup_model
+from TTS.tts.utils.generic_utils import setup_model
 from TTS.tts.utils.io import save_best_model, save_checkpoint
 from TTS.tts.utils.measures import alignment_diagonal_score
 from TTS.tts.utils.speakers import parse_speakers
@@ -26,14 +27,10 @@ from TTS.tts.utils.synthesis import synthesis
 from TTS.tts.utils.text.symbols import make_symbols, phonemes, symbols
 from TTS.tts.utils.visual import plot_alignment, plot_spectrogram
 from TTS.utils.audio import AudioProcessor
-from TTS.utils.console_logger import ConsoleLogger
 from TTS.utils.distribute import init_distributed, reduce_tensor
 from TTS.utils.generic_utils import (KeepAverage, count_parameters,
-                                     create_experiment_folder, get_git_branch,
                                      remove_experiment_folder, set_init_dict)
-from TTS.utils.io import copy_model_files, load_config
 from TTS.utils.radam import RAdam
-from TTS.utils.tensorboard_logger import TensorboardLogger
 from TTS.utils.training import NoamLR, setup_torch_training_env
 
 use_cuda, num_gpus = setup_torch_training_env(True, False)
@@ -175,13 +172,13 @@ def train(data_loader, model, criterion, optimizer, scheduler,
             scaler.scale(loss_dict['loss']).backward()
             scaler.unscale_(optimizer)
             grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(),
-                                                       c.grad_clip)
+                                           c.grad_clip)
             scaler.step(optimizer)
             scaler.update()
         else:
             loss_dict['loss'].backward()
             grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(),
-                                                       c.grad_clip)
+                                           c.grad_clip)
             optimizer.step()
 
         # setup lr
@@ -518,8 +515,7 @@ def main(args):  # pylint: disable=redefined-outer-name
         train_avg_loss_dict, global_step = train(train_loader, model, criterion, optimizer,
                                                  scheduler, ap, global_step,
                                                  epoch)
-        eval_avg_loss_dict = evaluate(eval_loader, model, criterion, ap,
-                                      global_step, epoch)
+        eval_avg_loss_dict = evaluate(eval_loader , model, criterion, ap, global_step, epoch)
         c_logger.print_epoch_end(epoch, eval_avg_loss_dict)
         target_loss = train_avg_loss_dict['avg_loss']
         if c.run_eval:
@@ -529,81 +525,9 @@ def main(args):  # pylint: disable=redefined-outer-name
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        '--continue_path',
-        type=str,
-        help='Training output folder to continue training. Use to continue a training. If it is used, "config_path" is ignored.',
-        default='',
-        required='--config_path' not in sys.argv)
-    parser.add_argument(
-        '--restore_path',
-        type=str,
-        help='Model file to be restored. Use to finetune a model.',
-        default='')
-    parser.add_argument(
-        '--config_path',
-        type=str,
-        help='Path to config file for training.',
-        required='--continue_path' not in sys.argv
-    )
-    parser.add_argument('--debug',
-                        type=bool,
-                        default=False,
-                        help='Do not verify commit integrity to run training.')
-
-    # DISTRUBUTED
-    parser.add_argument(
-        '--rank',
-        type=int,
-        default=0,
-        help='DISTRIBUTED: process rank for distributed training.')
-    parser.add_argument('--group_id',
-                        type=str,
-                        default="",
-                        help='DISTRIBUTED: process group id.')
-    args = parser.parse_args()
-
-    if args.continue_path != '':
-        args.output_path = args.continue_path
-        args.config_path = os.path.join(args.continue_path, 'config.json')
-        list_of_files = glob.glob(args.continue_path + "/*.pth.tar") # * means all if need specific format then *.csv
-        latest_model_file = max(list_of_files, key=os.path.getctime)
-        args.restore_path = latest_model_file
-        print(f" > Training continues for {args.restore_path}")
-
-    # setup output paths and read configs
-    c = load_config(args.config_path)
-    # check_config(c)
-    check_config_tts(c)
-    _ = os.path.dirname(os.path.realpath(__file__))
-
-    if c.mixed_precision:
-        print("   > Mixed precision enabled.")
-
-    OUT_PATH = args.continue_path
-    if args.continue_path == '':
-        OUT_PATH = create_experiment_folder(c.output_path, c.run_name, args.debug)
-
-    AUDIO_PATH = os.path.join(OUT_PATH, 'test_audios')
-
-    c_logger = ConsoleLogger()
-
-    if args.rank == 0:
-        os.makedirs(AUDIO_PATH, exist_ok=True)
-        new_fields = {}
-        if args.restore_path:
-            new_fields["restore_path"] = args.restore_path
-        new_fields["github_branch"] = get_git_branch()
-        copy_model_files(c, args.config_path, OUT_PATH, new_fields)
-        os.chmod(AUDIO_PATH, 0o775)
-        os.chmod(OUT_PATH, 0o775)
-
-        LOG_DIR = OUT_PATH
-        tb_logger = TensorboardLogger(LOG_DIR, model_name='TTS')
-
-        # write model desc to tensorboard
-        tb_logger.tb_add_text('model-description', c['run_description'], 0)
+    args = parse_arguments(sys.argv)
+    c, OUT_PATH, AUDIO_PATH, c_logger, tb_logger = process_args(
+        args, model_type='tts')
 
     try:
         main(args)

--- a/TTS/bin/train_speedy_speech.py
+++ b/TTS/bin/train_speedy_speech.py
@@ -172,13 +172,13 @@ def train(data_loader, model, criterion, optimizer, scheduler,
             scaler.scale(loss_dict['loss']).backward()
             scaler.unscale_(optimizer)
             grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(),
-                                           c.grad_clip)
+                                                       c.grad_clip)
             scaler.step(optimizer)
             scaler.update()
         else:
             loss_dict['loss'].backward()
             grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(),
-                                           c.grad_clip)
+                                                       c.grad_clip)
             optimizer.step()
 
         # setup lr
@@ -515,12 +515,14 @@ def main(args):  # pylint: disable=redefined-outer-name
         train_avg_loss_dict, global_step = train(train_loader, model, criterion, optimizer,
                                                  scheduler, ap, global_step,
                                                  epoch)
-        eval_avg_loss_dict = evaluate(eval_loader , model, criterion, ap, global_step, epoch)
+        eval_avg_loss_dict = evaluate(eval_loader , model, criterion, ap,
+                                      global_step, epoch)
         c_logger.print_epoch_end(epoch, eval_avg_loss_dict)
         target_loss = train_avg_loss_dict['avg_loss']
         if c.run_eval:
             target_loss = eval_avg_loss_dict['avg_loss']
-        best_loss = save_best_model(target_loss, best_loss, model, optimizer, global_step, epoch, c.r,
+        best_loss = save_best_model(target_loss, best_loss, model, optimizer,
+                                    global_step, epoch, c.r,
                                     OUT_PATH)
 
 

--- a/TTS/bin/train_tacotron.py
+++ b/TTS/bin/train_tacotron.py
@@ -56,12 +56,10 @@ def setup_loader(ap, r, is_val=False, verbose=False, dataset=None):
                 phoneme_language=c.phoneme_language,
                 enable_eos_bos=c.enable_eos_bos_chars,
                 verbose=verbose,
-                speaker_mapping=(
-                    speaker_mapping if (
-                        c.use_speaker_embedding and
-                        c.use_external_speaker_embedding_file
-                        ) else None
-                    )
+                speaker_mapping=(speaker_mapping if (
+                    c.use_speaker_embedding
+                    and c.use_external_speaker_embedding_file
+                    ) else None)
                 )
 
             if c.use_phonemes and c.compute_input_seq_cache:

--- a/TTS/bin/train_tacotron.py
+++ b/TTS/bin/train_tacotron.py
@@ -9,8 +9,8 @@ from random import randrange
 
 import numpy as np
 import torch
-from TTS.utils.arguments import parse_arguments, process_args
 from torch.utils.data import DataLoader
+from TTS.utils.arguments import parse_arguments, process_args
 from TTS.tts.datasets.preprocess import load_meta_data
 from TTS.tts.datasets.TTSDataset import MyDataset
 from TTS.tts.layers.losses import TacotronLoss
@@ -62,7 +62,7 @@ def setup_loader(ap, r, is_val=False, verbose=False, dataset=None):
                         c.use_external_speaker_embedding_file
                         ) else None
                     )
-                    )
+                )
 
             if c.use_phonemes and c.compute_input_seq_cache:
                 # precompute phonemes to have a better estimate of sequence lengths.
@@ -179,10 +179,10 @@ def train(data_loader, model, criterion, optimizer, optimizer_st, scheduler,
 
             # compute loss
             loss_dict = criterion(postnet_output, decoder_output, mel_input,
-                                linear_input, stop_tokens, stop_targets,
-                                mel_lengths, decoder_backward_output,
-                                alignments, alignment_lengths, alignments_backward,
-                                text_lengths)
+                                  linear_input, stop_tokens, stop_targets,
+                                  mel_lengths, decoder_backward_output,
+                                  alignments, alignment_lengths,
+                                  alignments_backward, text_lengths)
 
         # check nan loss
         if torch.isnan(loss_dict['loss']).any():
@@ -200,7 +200,7 @@ def train(data_loader, model, criterion, optimizer, optimizer_st, scheduler,
 
             # stopnet optimizer step
             if c.separate_stopnet:
-                scaler_st.scale( loss_dict['stopnet_loss']).backward()
+                scaler_st.scale(loss_dict['stopnet_loss']).backward()
                 scaler.unscale_(optimizer_st)
                 optimizer_st, _ = adam_weight_decay(optimizer_st)
                 grad_norm_st, _ = check_update(model.decoder.stopnet, 1.0)
@@ -534,8 +534,7 @@ def main(args):  # pylint: disable=redefined-outer-name
         optimizer_st = None
 
     # setup criterion
-    criterion = TacotronLoss(c, stopnet_pos_weight=10.0, ga_sigma=0.4)
-
+    criterion = TacotronLoss(c, stopnet_pos_weight=c.stopnet_pos_weight, ga_sigma=0.4)
     if args.restore_path:
         checkpoint = torch.load(args.restore_path, map_location='cpu')
         try:
@@ -637,7 +636,8 @@ def main(args):  # pylint: disable=redefined-outer-name
             epoch,
             c.r,
             OUT_PATH,
-            scaler=scaler.state_dict() if c.mixed_precision else None)
+            scaler=scaler.state_dict() if c.mixed_precision else None
+        )
 
 
 if __name__ == '__main__':

--- a/TTS/bin/train_vocoder_gan.py
+++ b/TTS/bin/train_vocoder_gan.py
@@ -8,8 +8,8 @@ import traceback
 from inspect import signature
 
 import torch
-from TTS.utils.arguments import parse_arguments, process_args
 from torch.utils.data import DataLoader
+from TTS.utils.arguments import parse_arguments, process_args
 from TTS.utils.audio import AudioProcessor
 from TTS.utils.generic_utils import (KeepAverage, count_parameters,
                                      remove_experiment_folder, set_init_dict)
@@ -33,9 +33,8 @@ use_cuda, num_gpus = setup_torch_training_env(True, True)
 
 
 def setup_loader(ap, is_val=False, verbose=False):
-    if is_val and not c.run_eval:
-        loader = None
-    else:
+    loader = None
+    if not is_val or c.run_eval:
         dataset = GANDataset(ap=ap,
                              items=eval_data if is_val else train_data,
                              seq_len=c.seq_len,
@@ -114,7 +113,7 @@ def train(model_G, criterion_G, optimizer_G, model_D, criterion_D, optimizer_D,
         y_hat = model_G(c_G)
         y_hat_sub = None
         y_G_sub = None
-        y_hat_vis = y_hat  # for visualization # FIXME! .clone().detach()
+        y_hat_vis = y_hat  # for visualization
 
         # PQMF formatting
         if y_hat.shape[1] > 1:
@@ -274,14 +273,14 @@ def train(model_G, criterion_G, optimizer_G, model_D, criterion_D, optimizer_D,
 
                 # compute spectrograms
                 figures = plot_results(y_hat_vis, y_G, ap, global_step,
-                                    'train')
+                                       'train')
                 tb_logger.tb_train_figures(global_step, figures)
 
                 # Sample audio
                 sample_voice = y_hat_vis[0].squeeze(0).detach().cpu().numpy()
                 tb_logger.tb_train_audios(global_step,
-                                        {'train/audio': sample_voice},
-                                        c.audio["sample_rate"])
+                                          {'train/audio': sample_voice},
+                                          c.audio["sample_rate"])
         end_time = time.time()
 
     # print epoch stats

--- a/TTS/bin/train_vocoder_gan.py
+++ b/TTS/bin/train_vocoder_gan.py
@@ -1,5 +1,6 @@
-import argparse
-import glob
+#!/usr/bin/env python3
+"""Trains GAN based vocoder model."""
+
 import os
 import sys
 import time
@@ -7,15 +8,14 @@ import traceback
 from inspect import signature
 
 import torch
+from TTS.utils.arguments import parse_arguments, process_args
 from torch.utils.data import DataLoader
 from TTS.utils.audio import AudioProcessor
-from TTS.utils.console_logger import ConsoleLogger
 from TTS.utils.generic_utils import (KeepAverage, count_parameters,
-                                     create_experiment_folder, get_git_branch,
                                      remove_experiment_folder, set_init_dict)
-from TTS.utils.io import copy_model_files, load_config
+
 from TTS.utils.radam import RAdam
-from TTS.utils.tensorboard_logger import TensorboardLogger
+
 from TTS.utils.training import setup_torch_training_env
 from TTS.vocoder.datasets.gan_dataset import GANDataset
 from TTS.vocoder.datasets.preprocess import load_wav_data, load_wav_feat_data
@@ -33,8 +33,9 @@ use_cuda, num_gpus = setup_torch_training_env(True, True)
 
 
 def setup_loader(ap, is_val=False, verbose=False):
-    loader = None
-    if not is_val or c.run_eval:
+    if is_val and not c.run_eval:
+        loader = None
+    else:
         dataset = GANDataset(ap=ap,
                              items=eval_data if is_val else train_data,
                              seq_len=c.seq_len,
@@ -113,7 +114,7 @@ def train(model_G, criterion_G, optimizer_G, model_D, criterion_D, optimizer_D,
         y_hat = model_G(c_G)
         y_hat_sub = None
         y_G_sub = None
-        y_hat_vis = y_hat  # for visualization
+        y_hat_vis = y_hat  # for visualization # FIXME! .clone().detach()
 
         # PQMF formatting
         if y_hat.shape[1] > 1:
@@ -273,14 +274,14 @@ def train(model_G, criterion_G, optimizer_G, model_D, criterion_D, optimizer_D,
 
                 # compute spectrograms
                 figures = plot_results(y_hat_vis, y_G, ap, global_step,
-                                       'train')
+                                    'train')
                 tb_logger.tb_train_figures(global_step, figures)
 
                 # Sample audio
                 sample_voice = y_hat_vis[0].squeeze(0).detach().cpu().numpy()
                 tb_logger.tb_train_audios(global_step,
-                                          {'train/audio': sample_voice},
-                                          c.audio["sample_rate"])
+                                        {'train/audio': sample_voice},
+                                        c.audio["sample_rate"])
         end_time = time.time()
 
     # print epoch stats
@@ -439,7 +440,6 @@ def evaluate(model_G, criterion_G, model_D, criterion_D, ap, global_step, epoch)
     return keep_avg.avg_values
 
 
-# FIXME: move args definition/parsing inside of main?
 def main(args):  # pylint: disable=redefined-outer-name
     # pylint: disable=global-variable-undefined
     global train_data, eval_data
@@ -506,7 +506,7 @@ def main(args):  # pylint: disable=redefined-outer-name
                 scheduler_disc.load_state_dict(checkpoint['scheduler_disc'])
                 scheduler_disc.optimizer = optimizer_disc
         except RuntimeError:
-            # retore only matching layers.
+            # restore only matching layers.
             print(" > Partial model initialization...")
             model_dict = model_gen.state_dict()
             model_dict = set_init_dict(model_dict, checkpoint['model'], c)
@@ -556,7 +556,8 @@ def main(args):  # pylint: disable=redefined-outer-name
                                model_disc, criterion_disc, optimizer_disc,
                                scheduler_gen, scheduler_disc, ap, global_step,
                                epoch)
-        eval_avg_loss_dict = evaluate(model_gen, criterion_gen, model_disc, criterion_disc, ap,
+        eval_avg_loss_dict = evaluate(model_gen, criterion_gen, model_disc,
+                                      criterion_disc, ap,
                                       global_step, epoch)
         c_logger.print_epoch_end(epoch, eval_avg_loss_dict)
         target_loss = eval_avg_loss_dict[c.target_loss]
@@ -575,78 +576,9 @@ def main(args):  # pylint: disable=redefined-outer-name
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        '--continue_path',
-        type=str,
-        help='Training output folder to continue training. Use to continue a training. If it is used, "config_path" is ignored.',
-        default='',
-        required='--config_path' not in sys.argv)
-    parser.add_argument(
-        '--restore_path',
-        type=str,
-        help='Model file to be restored. Use to finetune a model.',
-        default='')
-    parser.add_argument('--config_path',
-                        type=str,
-                        help='Path to config file for training.',
-                        required='--continue_path' not in sys.argv)
-    parser.add_argument('--debug',
-                        type=bool,
-                        default=False,
-                        help='Do not verify commit integrity to run training.')
-
-    # DISTRUBUTED
-    parser.add_argument(
-        '--rank',
-        type=int,
-        default=0,
-        help='DISTRIBUTED: process rank for distributed training.')
-    parser.add_argument('--group_id',
-                        type=str,
-                        default="",
-                        help='DISTRIBUTED: process group id.')
-    args = parser.parse_args()
-
-    if args.continue_path != '':
-        args.output_path = args.continue_path
-        args.config_path = os.path.join(args.continue_path, 'config.json')
-        list_of_files = glob.glob(
-            args.continue_path +
-            "/*.pth.tar")  # * means all if need specific format then *.csv
-        latest_model_file = max(list_of_files, key=os.path.getctime)
-        args.restore_path = latest_model_file
-        print(f" > Training continues for {args.restore_path}")
-
-    # setup output paths and read configs
-    c = load_config(args.config_path)
-    # check_config(c)
-    _ = os.path.dirname(os.path.realpath(__file__))
-
-    OUT_PATH = args.continue_path
-    if args.continue_path == '':
-        OUT_PATH = create_experiment_folder(c.output_path, c.run_name,
-                                            args.debug)
-
-    AUDIO_PATH = os.path.join(OUT_PATH, 'test_audios')
-
-    c_logger = ConsoleLogger()
-
-    if args.rank == 0:
-        os.makedirs(AUDIO_PATH, exist_ok=True)
-        new_fields = {}
-        if args.restore_path:
-            new_fields["restore_path"] = args.restore_path
-        new_fields["github_branch"] = get_git_branch()
-        copy_model_files(c, args.config_path, OUT_PATH, new_fields)
-        os.chmod(AUDIO_PATH, 0o775)
-        os.chmod(OUT_PATH, 0o775)
-
-        LOG_DIR = OUT_PATH
-        tb_logger = TensorboardLogger(LOG_DIR, model_name='VOCODER')
-
-        # write model desc to tensorboard
-        tb_logger.tb_add_text('model-description', c['run_description'], 0)
+    args = parse_arguments(sys.argv)
+    c, OUT_PATH, AUDIO_PATH, c_logger, tb_logger = process_args(
+        args, model_type='gan')
 
     try:
         main(args)

--- a/TTS/bin/train_vocoder_wavernn.py
+++ b/TTS/bin/train_vocoder_wavernn.py
@@ -178,18 +178,19 @@ def train(model, optimizer, criterion, scheduler, scaler, ap, global_step, epoch
         if global_step % c.save_step == 0:
             if c.checkpoint:
                 # save model
-                save_checkpoint(model,
-                                optimizer,
-                                scheduler,
-                                None,
-                                None,
-                                None,
-                                global_step,
-                                epoch,
-                                OUT_PATH,
-                                model_losses=loss_dict,
-                                scaler=scaler.state_dict() if c.mixed_precision else None
-                                )
+                save_checkpoint(
+                    model,
+                    optimizer,
+                    scheduler,
+                    None,
+                    None,
+                    None,
+                    global_step,
+                    epoch,
+                    OUT_PATH,
+                    model_losses=loss_dict,
+                    scaler=scaler.state_dict() if c.mixed_precision else None
+                )
 
             # synthesize a full voice
             rand_idx = random.randrange(0, len(train_data))
@@ -204,14 +205,7 @@ def train(model, optimizer, criterion, scheduler, scaler, ap, global_step, epoch
                                          c.batched,
                                          c.target_samples,
                                          c.overlap_samples,
-                                         # use_cuda
                                          )
-            # sample_wav = model.generate(ground_mel,
-            #                             c.batched,
-            #                             c.target_samples,
-            #                             c.overlap_samples,
-            #                             use_cuda
-            #                             )
             predict_mel = ap.melspectrogram(sample_wav)
 
             # compute spectrograms
@@ -300,7 +294,6 @@ def evaluate(model, criterion, ap, global_step, epoch):
                                      c.batched,
                                      c.target_samples,
                                      c.overlap_samples,
-                                     # use_cuda
                                      )
         predict_mel = ap.melspectrogram(sample_wav)
 
@@ -311,9 +304,10 @@ def evaluate(model, criterion, ap, global_step, epoch):
         )
 
         # compute spectrograms
-        figures = {"eval/ground_truth": plot_spectrogram(ground_mel.T),
-                   "eval/prediction": plot_spectrogram(predict_mel.T)
-                   }
+        figures = {
+            "eval/ground_truth": plot_spectrogram(ground_mel.T),
+            "eval/prediction": plot_spectrogram(predict_mel.T)
+        }
         tb_logger.tb_eval_figures(global_step, figures)
 
     tb_logger.tb_eval_stats(global_step, keep_avg.avg_values)

--- a/TTS/utils/arguments.py
+++ b/TTS/utils/arguments.py
@@ -35,7 +35,7 @@ def parse_arguments(argv):
         "--continue_path",
         type=str,
         help=("Training output folder to continue training. Used to continue "
-              "a training. If it is used, "config_path" is ignored."),
+              "a training. If it is used, 'config_path' is ignored."),
         default="",
         required="--config_path" not in argv)
     parser.add_argument(
@@ -151,6 +151,7 @@ def process_args(args, model_type):
             os.path.join(args.continue_path, "*.pth.tar")
             )  # * means all if need specific format then *.csv
         args.restore_path = max(list_of_files, key=os.path.getctime)
+        # checkpoint number based continuing
         # args.restore_path = get_last_checkpoint(args.continue_path)
         print(f" > Training continues for {args.restore_path}")
 

--- a/TTS/utils/arguments.py
+++ b/TTS/utils/arguments.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Argument parser for training scripts."""
+
+import argparse
+import re
+import glob
+import os
+
+from TTS.utils.generic_utils import (
+    create_experiment_folder, get_git_branch)
+from TTS.utils.console_logger import ConsoleLogger
+from TTS.utils.io import copy_model_files, load_config
+from TTS.utils.tensorboard_logger import TensorboardLogger
+
+from TTS.tts.utils.generic_utils import check_config_tts
+
+
+def parse_arguments(argv):
+    """Parse command line arguments of training scripts.
+
+    Parameters
+    ----------
+    argv : list
+        This is a list of input arguments as given by sys.argv
+
+    Returns
+    -------
+    argparse.Namespace
+        Parsed arguments.
+
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--continue_path",
+        type=str,
+        help=("Training output folder to continue training. Used to continue "
+              "a training. If it is used, "config_path" is ignored."),
+        default="",
+        required="--config_path" not in argv)
+    parser.add_argument(
+        "--restore_path",
+        type=str,
+        help="Model file to be restored. Use to finetune a model.",
+        default="")
+    parser.add_argument(
+        "--config_path",
+        type=str,
+        help="Path to config file for training.",
+        required="--continue_path" not in argv)
+    parser.add_argument(
+        "--debug",
+        type=bool,
+        default=False,
+        help="Do not verify commit integrity to run training.")
+    parser.add_argument(
+        "--rank",
+        type=int,
+        default=0,
+        help="DISTRIBUTED: process rank for distributed training.")
+    parser.add_argument(
+        "--group_id",
+        type=str,
+        default="",
+        help="DISTRIBUTED: process group id.")
+
+    return parser.parse_args()
+
+
+def get_last_checkpoint(path):
+    """Get latest checkpoint from a list of filenames.
+
+    It is based on globbing for `*.pth.tar` and the RegEx
+    `checkpoint_([0-9]+)`.
+
+    Parameters
+    ----------
+    path : list
+        Path to files to be compared.
+
+    Raises
+    ------
+    ValueError
+        If no checkpoint files are found.
+
+    Returns
+    -------
+    last_checkpoint : str
+        Last checkpoint filename.
+
+    """
+    last_checkpoint_num = 0
+    last_checkpoint = None
+    filenames = glob.glob(
+        os.path.join(path, "/*.pth.tar"))
+    for filename in filenames:
+        try:
+            checkpoint_num = int(
+                re.search(r"checkpoint_([0-9]+)", filename).groups()[0])
+            if checkpoint_num > last_checkpoint_num:
+                last_checkpoint_num = checkpoint_num
+                last_checkpoint = filename
+        except AttributeError:  # if there's no match in the filename
+            pass
+    if last_checkpoint is None:
+        raise ValueError(f"No checkpoints in {path}!")
+    else:
+        return last_checkpoint
+
+
+def process_args(args, model_type):
+    """Process parsed comand line arguments.
+
+    Parameters
+    ----------
+    args : argparse.Namespace or dict like
+        Parsed input arguments.
+    model_type : str
+        Model type used to check config parameters and setup the TensorBoard
+        logger. One of:
+            - tacotron
+            - glow_tts
+            - speedy_speech
+            - gan
+            - wavegrad
+            - wavernn
+
+    Raises
+    ------
+    ValueError
+        If `model_type` is not one of implemented choices.
+
+    Returns
+    -------
+    c : TTS.utils.io.AttrDict
+        Config paramaters.
+    out_path : str
+        Path to save models and logging.
+    audio_path : str
+        Path to save generated test audios.
+    c_logger : TTS.utils.console_logger.ConsoleLogger
+        Class that does logging to the console.
+    tb_logger : TTS.utils.tensorboard.TensorboardLogger
+        Class that does the TensorBoard loggind.
+
+    """
+    if args.continue_path != "":
+        args.output_path = args.continue_path
+        args.config_path = os.path.join(args.continue_path, "config.json")
+        list_of_files = glob.glob(
+            os.path.join(args.continue_path, "*.pth.tar")
+            )  # * means all if need specific format then *.csv
+        args.restore_path = max(list_of_files, key=os.path.getctime)
+        # args.restore_path = get_last_checkpoint(args.continue_path)
+        print(f" > Training continues for {args.restore_path}")
+
+    # setup output paths and read configs
+    c = load_config(args.config_path)
+
+    if model_type in "tacotron glow_tts speedy_speech":
+        model_class = "TTS"
+    elif model_type in "gan wavegrad wavernn":
+        model_class = "VOCODER"
+    else:
+        raise ValueError("model type {model_type} not recognized!")
+
+    if model_class == "TTS":
+        check_config_tts(c)
+    elif model_class == "VOCODER":
+        print("Vocoder config checker not implemented, "
+              "skipping ...")
+    else:
+        raise ValueError(f"model type {model_type} not recognized!")
+
+    _ = os.path.dirname(os.path.realpath(__file__))
+
+    if model_type in "tacotron wavegrad wavernn" and c.mixed_precision:
+        print("   >  Mixed precision mode is ON")
+
+    out_path = args.continue_path
+    if args.continue_path == "":
+        out_path = create_experiment_folder(c.output_path, c.run_name,
+                                            args.debug)
+
+    audio_path = os.path.join(out_path, "test_audios")
+
+    c_logger = ConsoleLogger()
+
+    if args.rank == 0:
+        os.makedirs(audio_path, exist_ok=True)
+        new_fields = {}
+        if args.restore_path:
+            new_fields["restore_path"] = args.restore_path
+        new_fields["github_branch"] = get_git_branch()
+        copy_model_files(c,  args.config_path,
+                         out_path, new_fields)
+        os.chmod(audio_path, 0o775)
+        os.chmod(out_path, 0o775)
+
+        log_path = out_path
+
+        tb_logger = TensorboardLogger(log_path, model_name=model_class)
+
+        # write model desc to tensorboard
+        tb_logger.tb_add_text("model-description", c["run_description"], 0)
+
+    return c, out_path, audio_path, c_logger, tb_logger


### PR DESCRIPTION
I've moved the command line parsing and processing from the `if __name__ == '__main__':` block into two separate functions in a new file `TTS/utils/arguments.py`. This avoids code douplication across the training scripts adhering to the DRY principle :slightly_smiling_face: 

It also solves the `FIXME` that was before the `main` function.

Currently updated:
- `train_glow_tts.py`
- `train_speedy_speech.py`
- `train_tacotron.py`
- `train_vocoder_gan.py`
- `train_vocoder_wavegrad.py`
- `train_vocoder_wavernn.py`

These still work as before, they are a bit different - but I can update them if necessary:
- `train_encoder.py`
- `tune_wavegrad.py`