### PR TITLE
Easy Fix for #454 (which was somehow deleted?)

### DIFF
--- a/TTS/utils/io.py
+++ b/TTS/utils/io.py
@@ -22,7 +22,7 @@ class AttrDict(dict):
 
 def read_json_with_comments(json_path):
     # fallback to json
-    with open(json_path, "r") as f:
+    with open(json_path, "r", encoding = "utf-8") as f:
         input_str = f.read()
     # handle comments
     input_str = re.sub(r'\\\n', '', input_str)
@@ -40,7 +40,7 @@ def load_config(config_path: str) -> AttrDict:
 
     ext = os.path.splitext(config_path)[1]
     if ext in (".yml", ".yaml"):
-        with open(config_path, "r") as f:
+        with open(config_path, "r", encoding = "utf-8") as f:
             data = yaml.safe_load(f)
     else:
         data = read_json_with_comments(config_path)
@@ -61,7 +61,7 @@ def copy_model_files(c, config_file, out_path, new_fields):
     """
     # copy config.json
     copy_config_path = os.path.join(out_path, 'config.json')
-    config_lines = open(config_file, "r").readlines()
+    config_lines = open(config_file, "r", encoding = "utf-8").readlines()
     # add extra information fields
     for key, value in new_fields.items():
         if isinstance(value, str):


### PR DESCRIPTION
#456, #454
#605
Somehow the code was LOST even though it was fixed _before_, so lately the issue just keeps popping up for Windows users, like in [here](https://github.com/mozilla/TTS/issues/617#issuecomment-763138841).

I did the same thing as [lokkelvin2 here](https://github.com/mozilla/TTS/pull/456#issue-448127246):
"Replaced with open(config_path, "r") as f: with with open(config_path, "r", encoding = "utf-8") as f: in TTS\utils\io.py.

Fixes UnicodeDecodeError for Windows 10 in #454"