### PR TITLE
Best model saving and loading updates

### DIFF
--- a/TTS/bin/train_glow_tts.py
+++ b/TTS/bin/train_glow_tts.py
@@ -497,6 +497,7 @@ def main(args):  # pylint: disable=redefined-outer-name
     criterion = GlowTTSLoss()
 
     if args.restore_path:
+        print(f" > Restoring from {os.path.basename(args.restore_path)} ...")
         checkpoint = torch.load(args.restore_path, map_location='cpu')
         try:
             # TODO: fix optimizer init, model.cuda() needs to be called before
@@ -514,7 +515,7 @@ def main(args):  # pylint: disable=redefined-outer-name
 
         for group in optimizer.param_groups:
             group['initial_lr'] = c.lr
-        print(" > Model restored from step %d" % checkpoint['step'],
+        print(f" > Model restored from step {checkpoint['step']:d}",
               flush=True)
         args.restore_step = checkpoint['step']
     else:
@@ -542,7 +543,8 @@ def main(args):  # pylint: disable=redefined-outer-name
         best_loss = float('inf')
         print(" > Starting with inf best loss.")
     else:
-        print(args.best_path)
+        print(" > Restoring best loss from "
+              f"{os.path.basename(args.best_path)} ...")
         best_loss = torch.load(args.best_path,
                                map_location='cpu')['model_loss']
         print(f" > Starting with loaded last best loss {best_loss}.")

--- a/TTS/bin/train_glow_tts.py
+++ b/TTS/bin/train_glow_tts.py
@@ -548,8 +548,8 @@ def main(args):  # pylint: disable=redefined-outer-name
         best_loss = torch.load(args.best_path,
                                map_location='cpu')['model_loss']
         print(f" > Starting with loaded last best loss {best_loss}.")
-    keep_best = c.get('keep_best', False)
-    keep_after = c.get('keep_after', 10000)  # void if keep_best False
+    keep_all_best = c.get('keep_all_best', False)
+    keep_after = c.get('keep_after', 10000)  # void if keep_all_best False
 
     # define dataloaders
     train_loader = setup_loader(ap, 1, is_val=False, verbose=True)
@@ -571,7 +571,7 @@ def main(args):  # pylint: disable=redefined-outer-name
             target_loss = eval_avg_loss_dict['avg_loss']
         best_loss = save_best_model(target_loss, best_loss, model, optimizer,
                                     global_step, epoch, c.r, OUT_PATH,
-                                    keep_best=keep_best, keep_after=keep_after)
+                                    keep_all_best=keep_all_best, keep_after=keep_after)
 
 
 if __name__ == '__main__':

--- a/TTS/bin/train_speedy_speech.py
+++ b/TTS/bin/train_speedy_speech.py
@@ -512,8 +512,8 @@ def main(args):  # pylint: disable=redefined-outer-name
         best_loss = torch.load(args.best_path,
                                map_location='cpu')['model_loss']
         print(f" > Starting with loaded last best loss {best_loss}.")
-    keep_best = c.get('keep_best', False)
-    keep_after = c.get('keep_after', 10000)  # void if keep_best False
+    keep_all_best = c.get('keep_all_best', False)
+    keep_after = c.get('keep_after', 10000)  # void if keep_all_best False
 
     # define dataloaders
     train_loader = setup_loader(ap, 1, is_val=False, verbose=True)
@@ -533,7 +533,7 @@ def main(args):  # pylint: disable=redefined-outer-name
             target_loss = eval_avg_loss_dict['avg_loss']
         best_loss = save_best_model(target_loss, best_loss, model, optimizer,
                                     global_step, epoch, c.r, OUT_PATH,
-                                    keep_best=keep_best, keep_after=keep_after)
+                                    keep_all_best=keep_all_best, keep_after=keep_after)
 
 
 if __name__ == '__main__':

--- a/TTS/bin/train_speedy_speech.py
+++ b/TTS/bin/train_speedy_speech.py
@@ -461,6 +461,7 @@ def main(args):  # pylint: disable=redefined-outer-name
     criterion = SpeedySpeechLoss(c)
 
     if args.restore_path:
+        print(f" > Restoring from {os.path.basename(args.restore_path)} ...")
         checkpoint = torch.load(args.restore_path, map_location='cpu')
         try:
             # TODO: fix optimizer init, model.cuda() needs to be called before
@@ -506,7 +507,8 @@ def main(args):  # pylint: disable=redefined-outer-name
         best_loss = float('inf')
         print(" > Starting with inf best loss.")
     else:
-        print(args.best_path)
+        print(" > Restoring best loss from "
+              f"{os.path.basename(args.best_path)} ...")
         best_loss = torch.load(args.best_path,
                                map_location='cpu')['model_loss']
         print(f" > Starting with loaded last best loss {best_loss}.")

--- a/TTS/bin/train_speedy_speech.py
+++ b/TTS/bin/train_speedy_speech.py
@@ -502,8 +502,16 @@ def main(args):  # pylint: disable=redefined-outer-name
     num_params = count_parameters(model)
     print("\n > Model has {} parameters".format(num_params), flush=True)
 
-    if 'best_loss' not in locals():
+    if args.restore_step == 0 or not args.best_path:
         best_loss = float('inf')
+        print(" > Starting with inf best loss.")
+    else:
+        print(args.best_path)
+        best_loss = torch.load(args.best_path,
+                               map_location='cpu')['model_loss']
+        print(f" > Starting with loaded last best loss {best_loss}.")
+    keep_best = c.get('keep_best', False)
+    keep_after = c.get('keep_after', 10000)  # void if keep_best False
 
     # define dataloaders
     train_loader = setup_loader(ap, 1, is_val=False, verbose=True)
@@ -522,8 +530,8 @@ def main(args):  # pylint: disable=redefined-outer-name
         if c.run_eval:
             target_loss = eval_avg_loss_dict['avg_loss']
         best_loss = save_best_model(target_loss, best_loss, model, optimizer,
-                                    global_step, epoch, c.r,
-                                    OUT_PATH)
+                                    global_step, epoch, c.r, OUT_PATH,
+                                    keep_best=keep_best, keep_after=keep_after)
 
 
 if __name__ == '__main__':

--- a/TTS/bin/train_tacotron.py
+++ b/TTS/bin/train_tacotron.py
@@ -534,12 +534,13 @@ def main(args):  # pylint: disable=redefined-outer-name
     # setup criterion
     criterion = TacotronLoss(c, stopnet_pos_weight=c.stopnet_pos_weight, ga_sigma=0.4)
     if args.restore_path:
+        print(f" > Restoring from {os.path.basename(args.restore_path)}...")
         checkpoint = torch.load(args.restore_path, map_location='cpu')
         try:
-            print(" > Restoring Model.")
+            print(" > Restoring Model...")
             model.load_state_dict(checkpoint['model'])
             # optimizer restore
-            print(" > Restoring Optimizer.")
+            print(" > Restoring Optimizer...")
             optimizer.load_state_dict(checkpoint['optimizer'])
             if "scaler" in checkpoint and c.mixed_precision:
                 print(" > Restoring AMP Scaler...")
@@ -547,7 +548,7 @@ def main(args):  # pylint: disable=redefined-outer-name
             if c.reinit_layers:
                 raise RuntimeError
         except (KeyError, RuntimeError):
-            print(" > Partial model initialization.")
+            print(" > Partial model initialization...")
             model_dict = model.state_dict()
             model_dict = set_init_dict(model_dict, checkpoint['model'], c)
             # torch.save(model_dict, os.path.join(OUT_PATH, 'state_dict.pt'))
@@ -585,7 +586,8 @@ def main(args):  # pylint: disable=redefined-outer-name
         best_loss = float('inf')
         print(" > Starting with inf best loss.")
     else:
-        print(args.best_path)
+        print(" > Restoring best loss from "
+              f"{os.path.basename(args.best_path)} ...")
         best_loss = torch.load(args.best_path,
                                map_location='cpu')['model_loss']
         print(f" > Starting with loaded last best loss {best_loss}.")

--- a/TTS/bin/train_tacotron.py
+++ b/TTS/bin/train_tacotron.py
@@ -581,8 +581,16 @@ def main(args):  # pylint: disable=redefined-outer-name
     num_params = count_parameters(model)
     print("\n > Model has {} parameters".format(num_params), flush=True)
 
-    if 'best_loss' not in locals():
+    if args.restore_step == 0 or not args.best_path:
         best_loss = float('inf')
+        print(" > Starting with inf best loss.")
+    else:
+        print(args.best_path)
+        best_loss = torch.load(args.best_path,
+                               map_location='cpu')['model_loss']
+        print(f" > Starting with loaded last best loss {best_loss}.")
+    keep_best = c.get('keep_best', False)
+    keep_after = c.get('keep_after', 10000)  # void if keep_best False
 
     # define data loaders
     train_loader = setup_loader(ap,
@@ -634,6 +642,8 @@ def main(args):  # pylint: disable=redefined-outer-name
             epoch,
             c.r,
             OUT_PATH,
+            keep_best=keep_best,
+            keep_after=keep_after,
             scaler=scaler.state_dict() if c.mixed_precision else None
         )
 

--- a/TTS/bin/train_tacotron.py
+++ b/TTS/bin/train_tacotron.py
@@ -591,8 +591,8 @@ def main(args):  # pylint: disable=redefined-outer-name
         best_loss = torch.load(args.best_path,
                                map_location='cpu')['model_loss']
         print(f" > Starting with loaded last best loss {best_loss}.")
-    keep_best = c.get('keep_best', False)
-    keep_after = c.get('keep_after', 10000)  # void if keep_best False
+    keep_all_best = c.get('keep_all_best', False)
+    keep_after = c.get('keep_after', 10000)  # void if keep_all_best False
 
     # define data loaders
     train_loader = setup_loader(ap,
@@ -644,7 +644,7 @@ def main(args):  # pylint: disable=redefined-outer-name
             epoch,
             c.r,
             OUT_PATH,
-            keep_best=keep_best,
+            keep_all_best=keep_all_best,
             keep_after=keep_after,
             scaler=scaler.state_dict() if c.mixed_precision else None
         )

--- a/TTS/bin/train_vocoder_gan.py
+++ b/TTS/bin/train_vocoder_gan.py
@@ -555,8 +555,8 @@ def main(args):  # pylint: disable=redefined-outer-name
         best_loss = torch.load(args.best_path,
                                map_location='cpu')['model_loss']
         print(f" > Starting with best loss of {best_loss}.")
-    keep_best = c.get('keep_best', False)
-    keep_after = c.get('keep_after', 10000)  # void if keep_best False
+    keep_all_best = c.get('keep_all_best', False)
+    keep_after = c.get('keep_after', 10000)  # void if keep_all_best False
 
     global_step = args.restore_step
     for epoch in range(0, c.epochs):
@@ -581,7 +581,7 @@ def main(args):  # pylint: disable=redefined-outer-name
                                     global_step,
                                     epoch,
                                     OUT_PATH,
-                                    keep_best=keep_best,
+                                    keep_all_best=keep_all_best,
                                     keep_after=keep_after,
                                     model_losses=eval_avg_loss_dict,
                                     )

--- a/TTS/bin/train_vocoder_gan.py
+++ b/TTS/bin/train_vocoder_gan.py
@@ -485,6 +485,7 @@ def main(args):  # pylint: disable=redefined-outer-name
     criterion_disc = DiscriminatorLoss(c)
 
     if args.restore_path:
+        print(f" > Restoring from {os.path.basename(args.restore_path)}...")
         checkpoint = torch.load(args.restore_path, map_location='cpu')
         try:
             print(" > Restoring Generator Model...")
@@ -523,7 +524,7 @@ def main(args):  # pylint: disable=redefined-outer-name
         for group in optimizer_disc.param_groups:
             group['lr'] = c.lr_disc
 
-        print(" > Model restored from step %d" % checkpoint['step'],
+        print(f" > Model restored from step {checkpoint['step']:d}",
               flush=True)
         args.restore_step = checkpoint['step']
     else:
@@ -549,10 +550,11 @@ def main(args):  # pylint: disable=redefined-outer-name
         best_loss = float('inf')
         print(" > Starting with inf best loss.")
     else:
-        print(args.best_path)
+        print(" > Restoring best loss from "
+              f"{os.path.basename(args.best_path)} ...")
         best_loss = torch.load(args.best_path,
                                map_location='cpu')['model_loss']
-        print(f" > Starting with loaded last best loss {best_loss}.")
+        print(f" > Starting with best loss of {best_loss}.")
     keep_best = c.get('keep_best', False)
     keep_after = c.get('keep_after', 10000)  # void if keep_best False
 

--- a/TTS/bin/train_vocoder_gan.py
+++ b/TTS/bin/train_vocoder_gan.py
@@ -545,8 +545,16 @@ def main(args):  # pylint: disable=redefined-outer-name
     num_params = count_parameters(model_disc)
     print(" > Discriminator has {} parameters".format(num_params), flush=True)
 
-    if 'best_loss' not in locals():
+    if args.restore_step == 0 or not args.best_path:
         best_loss = float('inf')
+        print(" > Starting with inf best loss.")
+    else:
+        print(args.best_path)
+        best_loss = torch.load(args.best_path,
+                               map_location='cpu')['model_loss']
+        print(f" > Starting with loaded last best loss {best_loss}.")
+    keep_best = c.get('keep_best', False)
+    keep_after = c.get('keep_after', 10000)  # void if keep_best False
 
     global_step = args.restore_step
     for epoch in range(0, c.epochs):
@@ -571,7 +579,10 @@ def main(args):  # pylint: disable=redefined-outer-name
                                     global_step,
                                     epoch,
                                     OUT_PATH,
-                                    model_losses=eval_avg_loss_dict)
+                                    keep_best=keep_best,
+                                    keep_after=keep_after,
+                                    model_losses=eval_avg_loss_dict,
+                                    )
 
 
 if __name__ == '__main__':

--- a/TTS/bin/train_vocoder_wavegrad.py
+++ b/TTS/bin/train_vocoder_wavegrad.py
@@ -354,6 +354,7 @@ def main(args):  # pylint: disable=redefined-outer-name
         criterion.cuda()
 
     if args.restore_path:
+        print(f" > Restoring from {os.path.basename(args.restore_path)}...")
         checkpoint = torch.load(args.restore_path, map_location='cpu')
         try:
             print(" > Restoring Model...")
@@ -397,7 +398,8 @@ def main(args):  # pylint: disable=redefined-outer-name
         best_loss = float('inf')
         print(" > Starting with inf best loss.")
     else:
-        print(args.best_path)
+        print(" > Restoring best loss from "
+              f"{os.path.basename(args.best_path)} ...")
         best_loss = torch.load(args.best_path,
                                map_location='cpu')['model_loss']
         print(f" > Starting with loaded last best loss {best_loss}.")

--- a/TTS/bin/train_vocoder_wavegrad.py
+++ b/TTS/bin/train_vocoder_wavegrad.py
@@ -393,8 +393,16 @@ def main(args):  # pylint: disable=redefined-outer-name
     num_params = count_parameters(model)
     print(" > WaveGrad has {} parameters".format(num_params), flush=True)
 
-    if 'best_loss' not in locals():
+    if args.restore_step == 0 or not args.best_path:
         best_loss = float('inf')
+        print(" > Starting with inf best loss.")
+    else:
+        print(args.best_path)
+        best_loss = torch.load(args.best_path,
+                               map_location='cpu')['model_loss']
+        print(f" > Starting with loaded last best loss {best_loss}.")
+    keep_best = c.get('keep_best', False)
+    keep_after = c.get('keep_after', 10000)  # void if keep_best False
 
     global_step = args.restore_step
     for epoch in range(0, c.epochs):
@@ -416,6 +424,8 @@ def main(args):  # pylint: disable=redefined-outer-name
             global_step,
             epoch,
             OUT_PATH,
+            keep_best=keep_best,
+            keep_after=keep_after,
             model_losses=eval_avg_loss_dict,
             scaler=scaler.state_dict() if c.mixed_precision else None
         )

--- a/TTS/bin/train_vocoder_wavegrad.py
+++ b/TTS/bin/train_vocoder_wavegrad.py
@@ -403,8 +403,8 @@ def main(args):  # pylint: disable=redefined-outer-name
         best_loss = torch.load(args.best_path,
                                map_location='cpu')['model_loss']
         print(f" > Starting with loaded last best loss {best_loss}.")
-    keep_best = c.get('keep_best', False)
-    keep_after = c.get('keep_after', 10000)  # void if keep_best False
+    keep_all_best = c.get('keep_all_best', False)
+    keep_after = c.get('keep_after', 10000)  # void if keep_all_best False
 
     global_step = args.restore_step
     for epoch in range(0, c.epochs):
@@ -426,7 +426,7 @@ def main(args):  # pylint: disable=redefined-outer-name
             global_step,
             epoch,
             OUT_PATH,
-            keep_best=keep_best,
+            keep_all_best=keep_all_best,
             keep_after=keep_after,
             model_losses=eval_avg_loss_dict,
             scaler=scaler.state_dict() if c.mixed_precision else None

--- a/TTS/bin/train_vocoder_wavernn.py
+++ b/TTS/bin/train_vocoder_wavernn.py
@@ -416,8 +416,16 @@ def main(args):  # pylint: disable=redefined-outer-name
     num_parameters = count_parameters(model_wavernn)
     print(" > Model has {} parameters".format(num_parameters), flush=True)
 
-    if "best_loss" not in locals():
-        best_loss = float("inf")
+    if args.restore_step == 0 or not args.best_path:
+        best_loss = float('inf')
+        print(" > Starting with inf best loss.")
+    else:
+        print(args.best_path)
+        best_loss = torch.load(args.best_path,
+                               map_location='cpu')['model_loss']
+        print(f" > Starting with loaded last best loss {best_loss}.")
+    keep_best = c.get('keep_best', False)
+    keep_after = c.get('keep_after', 10000)  # void if keep_best False
 
     global_step = args.restore_step
     for epoch in range(0, c.epochs):
@@ -440,6 +448,8 @@ def main(args):  # pylint: disable=redefined-outer-name
             global_step,
             epoch,
             OUT_PATH,
+            keep_best=keep_best,
+            keep_after=keep_after,
             model_losses=eval_avg_loss_dict,
             scaler=scaler.state_dict() if c.mixed_precision else None
         )

--- a/TTS/bin/train_vocoder_wavernn.py
+++ b/TTS/bin/train_vocoder_wavernn.py
@@ -426,8 +426,8 @@ def main(args):  # pylint: disable=redefined-outer-name
         best_loss = torch.load(args.best_path,
                                map_location='cpu')['model_loss']
         print(f" > Starting with loaded last best loss {best_loss}.")
-    keep_best = c.get('keep_best', False)
-    keep_after = c.get('keep_after', 10000)  # void if keep_best False
+    keep_all_best = c.get('keep_all_best', False)
+    keep_after = c.get('keep_after', 10000)  # void if keep_all_best False
 
     global_step = args.restore_step
     for epoch in range(0, c.epochs):
@@ -450,7 +450,7 @@ def main(args):  # pylint: disable=redefined-outer-name
             global_step,
             epoch,
             OUT_PATH,
-            keep_best=keep_best,
+            keep_all_best=keep_all_best,
             keep_after=keep_after,
             model_losses=eval_avg_loss_dict,
             scaler=scaler.state_dict() if c.mixed_precision else None

--- a/TTS/bin/train_vocoder_wavernn.py
+++ b/TTS/bin/train_vocoder_wavernn.py
@@ -383,6 +383,7 @@ def main(args):  # pylint: disable=redefined-outer-name
 
     # restore any checkpoint
     if args.restore_path:
+        print(f" > Restoring from {os.path.basename(args.restore_path)}...")
         checkpoint = torch.load(args.restore_path, map_location="cpu")
         try:
             print(" > Restoring Model...")
@@ -420,7 +421,8 @@ def main(args):  # pylint: disable=redefined-outer-name
         best_loss = float('inf')
         print(" > Starting with inf best loss.")
     else:
-        print(args.best_path)
+        print(" > Restoring best loss from "
+              f"{os.path.basename(args.best_path)} ...")
         best_loss = torch.load(args.best_path,
                                map_location='cpu')['model_loss']
         print(f" > Starting with loaded last best loss {best_loss}.")

--- a/TTS/tts/configs/config.json
+++ b/TTS/tts/configs/config.json
@@ -121,8 +121,8 @@
     "print_eval": false,     // If True, it prints intermediate loss values in evalulation.
     "save_step": 10000,      // Number of training steps expected to save traninpg stats and checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
-    "keep_best": false,  // If true, keeps all best_models after keep_after steps
-    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
+    "keep_all_best": false,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_all_best is true
     "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
     // DATA LOADING

--- a/TTS/tts/configs/config.json
+++ b/TTS/tts/configs/config.json
@@ -121,6 +121,8 @@
     "print_eval": false,     // If True, it prints intermediate loss values in evalulation.
     "save_step": 10000,      // Number of training steps expected to save traninpg stats and checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
+    "keep_best": false,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
     "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
     // DATA LOADING

--- a/TTS/tts/configs/glow_tts_gated_conv.json
+++ b/TTS/tts/configs/glow_tts_gated_conv.json
@@ -93,8 +93,8 @@
     "print_eval": false,     // If True, it prints intermediate loss values in evalulation.
     "save_step": 5000,      // Number of training steps expected to save traninpg stats and checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
-    "keep_best": false,  // If true, keeps all best_models after keep_after steps
-    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
+    "keep_all_best": false,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_all_best is true
     "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
     "apex_amp_level": null,
 

--- a/TTS/tts/configs/glow_tts_gated_conv.json
+++ b/TTS/tts/configs/glow_tts_gated_conv.json
@@ -93,6 +93,8 @@
     "print_eval": false,     // If True, it prints intermediate loss values in evalulation.
     "save_step": 5000,      // Number of training steps expected to save traninpg stats and checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
+    "keep_best": false,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
     "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
     "apex_amp_level": null,
 

--- a/TTS/tts/configs/glow_tts_ljspeech.json
+++ b/TTS/tts/configs/glow_tts_ljspeech.json
@@ -105,8 +105,8 @@
         "print_eval": false,     // If True, it prints intermediate loss values in evalulation.
         "save_step": 5000,      // Number of training steps expected to save traninpg stats and checkpoints.
         "checkpoint": true,     // If true, it saves checkpoints per "save_step"
-        "keep_best": false,  // If true, keeps all best_models after keep_after steps
-        "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
+        "keep_all_best": false,  // If true, keeps all best_models after keep_after steps
+        "keep_after": 10000,    // Global step after which to keep best models if keep_all_best is true
         "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
         // DATA LOADING

--- a/TTS/tts/configs/glow_tts_ljspeech.json
+++ b/TTS/tts/configs/glow_tts_ljspeech.json
@@ -105,6 +105,8 @@
         "print_eval": false,     // If True, it prints intermediate loss values in evalulation.
         "save_step": 5000,      // Number of training steps expected to save traninpg stats and checkpoints.
         "checkpoint": true,     // If true, it saves checkpoints per "save_step"
+        "keep_best": false,  // If true, keeps all best_models after keep_after steps
+        "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
         "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
         // DATA LOADING

--- a/TTS/tts/configs/ljspeech_tacotron2_dynamic_conv_attn.json
+++ b/TTS/tts/configs/ljspeech_tacotron2_dynamic_conv_attn.json
@@ -121,8 +121,8 @@
     "print_eval": false,     // If True, it prints intermediate loss values in evalulation.
     "save_step": 10000,      // Number of training steps expected to save traninpg stats and checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
-    "keep_best": false,  // If true, keeps all best_models after keep_after steps
-    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
+    "keep_all_best": false,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_all_best is true
     "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
     // DATA LOADING

--- a/TTS/tts/configs/ljspeech_tacotron2_dynamic_conv_attn.json
+++ b/TTS/tts/configs/ljspeech_tacotron2_dynamic_conv_attn.json
@@ -121,6 +121,8 @@
     "print_eval": false,     // If True, it prints intermediate loss values in evalulation.
     "save_step": 10000,      // Number of training steps expected to save traninpg stats and checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
+    "keep_best": false,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
     "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
     // DATA LOADING

--- a/TTS/tts/configs/speedy_speech_ljspeech.json
+++ b/TTS/tts/configs/speedy_speech_ljspeech.json
@@ -109,6 +109,8 @@
    "print_eval": false,     // If True, it prints intermediate loss values in evalulation.
    "save_step": 5000,      // Number of training steps expected to save traninpg stats and checkpoints.
    "checkpoint": true,     // If true, it saves checkpoints per "save_step"
+   "keep_best": false,  // If true, keeps all best_models after keep_after steps
+   "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
    "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.:set n
    "mixed_precision": false,
 

--- a/TTS/tts/configs/speedy_speech_ljspeech.json
+++ b/TTS/tts/configs/speedy_speech_ljspeech.json
@@ -109,8 +109,8 @@
    "print_eval": false,     // If True, it prints intermediate loss values in evalulation.
    "save_step": 5000,      // Number of training steps expected to save traninpg stats and checkpoints.
    "checkpoint": true,     // If true, it saves checkpoints per "save_step"
-   "keep_best": false,  // If true, keeps all best_models after keep_after steps
-   "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
+   "keep_all_best": false,  // If true, keeps all best_models after keep_after steps
+   "keep_after": 10000,    // Global step after which to keep best models if keep_all_best is true
    "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.:set n
    "mixed_precision": false,
 

--- a/TTS/utils/arguments.py
+++ b/TTS/utils/arguments.py
@@ -68,7 +68,7 @@ def parse_arguments(argv):
     return parser.parse_args()
 
 
-def get_last_models(path):
+def get_last_checkpoint(path):
     """Get latest checkpoint or/and best model in path.
 
     It is based on globbing for `*.pth.tar` and the RegEx
@@ -145,7 +145,7 @@ def process_args(args, model_type):
     if args.continue_path:
         args.output_path = args.continue_path
         args.config_path = os.path.join(args.continue_path, "config.json")
-        args.restore_path, best_model = get_last_models(args.continue_path)
+        args.restore_path, best_model = get_last_checkpoint(args.continue_path)
         if not args.best_path:
             args.best_path = best_model
 

--- a/TTS/utils/arguments.py
+++ b/TTS/utils/arguments.py
@@ -169,7 +169,6 @@ def process_args(args, model_type):
         args.restore_path, best_model = get_last_models(args.continue_path)
         if not args.best_path:
             args.best_path = best_model
-        print(f" > Training continues for {args.restore_path}")
 
     # setup output paths and read configs
     c = load_config(args.config_path)
@@ -184,8 +183,7 @@ def process_args(args, model_type):
     if model_class == "TTS":
         check_config_tts(c)
     elif model_class == "VOCODER":
-        print("Vocoder config checker not implemented, "
-              "skipping ...")
+        print("Vocoder config checker not implemented, skipping ...")
     else:
         raise ValueError(f"model type {model_type} not recognized!")
 

--- a/TTS/utils/arguments.py
+++ b/TTS/utils/arguments.py
@@ -19,16 +19,11 @@ from TTS.tts.utils.generic_utils import check_config_tts
 def parse_arguments(argv):
     """Parse command line arguments of training scripts.
 
-    Parameters
-    ----------
-    argv : list
-        This is a list of input arguments as given by sys.argv
+    Args:
+        argv (list): This is a list of input arguments as given by sys.argv
 
-    Returns
-    -------
-    argparse.Namespace
-        Parsed arguments.
-
+    Returns:
+        argparse.Namespace: Parsed arguments.
     """
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -46,7 +41,8 @@ def parse_arguments(argv):
     parser.add_argument(
         "--best_path",
         type=str,
-        help="Best model file to be used for extracting best loss.",
+        help=("Best model file to be used for extracting best loss."
+              "If not specified, the latest best model in continue path is used"),
         default="")
     parser.add_argument(
         "--config_path",
@@ -78,21 +74,14 @@ def get_last_models(path):
     It is based on globbing for `*.pth.tar` and the RegEx
     `(checkpoint|best_model)_([0-9]+)`.
 
-    Parameters
-    ----------
-    path : list
-        Path to files to be compared.
+    Args:
+        path (list): Path to files to be compared.
 
-    Raises
-    ------
-    ValueError
-        If no checkpoint or best_model files are found.
+    Raises:
+        ValueError: If no checkpoint or best_model files are found.
 
-    Returns
-    -------
-    last_checkpoint : str
-        Last checkpoint filename.
-
+    Returns:
+        last_checkpoint (str): Last checkpoint filename.
     """
     file_names = glob.glob(os.path.join(path, "*.pth.tar"))
     last_models = {}
@@ -130,38 +119,28 @@ def get_last_models(path):
 def process_args(args, model_type):
     """Process parsed comand line arguments.
 
-    Parameters
-    ----------
-    args : argparse.Namespace or dict like
-        Parsed input arguments.
-    model_type : str
-        Model type used to check config parameters and setup the TensorBoard
-        logger. One of:
-            - tacotron
-            - glow_tts
-            - speedy_speech
-            - gan
-            - wavegrad
-            - wavernn
+    Args:
+        args (argparse.Namespace or dict like): Parsed input arguments.
+        model_type (str): Model type used to check config parameters and setup
+            the TensorBoard logger. One of:
+                - tacotron
+                - glow_tts
+                - speedy_speech
+                - gan
+                - wavegrad
+                - wavernn
 
-    Raises
-    ------
-    ValueError
-        If `model_type` is not one of implemented choices.
+    Raises:
+        ValueError: If `model_type` is not one of implemented choices.
 
-    Returns
-    -------
-    c : TTS.utils.io.AttrDict
-        Config paramaters.
-    out_path : str
-        Path to save models and logging.
-    audio_path : str
-        Path to save generated test audios.
-    c_logger : TTS.utils.console_logger.ConsoleLogger
-        Class that does logging to the console.
-    tb_logger : TTS.utils.tensorboard.TensorboardLogger
-        Class that does the TensorBoard loggind.
-
+    Returns:
+        c (TTS.utils.io.AttrDict): Config paramaters.
+        out_path (str): Path to save models and logging.
+        audio_path (str): Path to save generated test audios.
+        c_logger (TTS.utils.console_logger.ConsoleLogger): Class that does
+            logging to the console.
+        tb_logger (TTS.utils.tensorboard.TensorboardLogger): Class that does
+            the TensorBoard loggind.
     """
     if args.continue_path:
         args.output_path = args.continue_path

--- a/TTS/vocoder/configs/multiband-melgan_and_rwd_config.json
+++ b/TTS/vocoder/configs/multiband-melgan_and_rwd_config.json
@@ -138,8 +138,8 @@
     "print_eval": false,     // If True, it prints loss values for each step in eval run.
     "save_step": 25000,      // Number of training steps expected to plot training stats on TB and save model checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
-    "keep_best": false,  // If true, keeps all best_models after keep_after steps
-    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
+    "keep_all_best": false,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_all_best is true
     "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
     // DATA LOADING

--- a/TTS/vocoder/configs/multiband-melgan_and_rwd_config.json
+++ b/TTS/vocoder/configs/multiband-melgan_and_rwd_config.json
@@ -138,6 +138,8 @@
     "print_eval": false,     // If True, it prints loss values for each step in eval run.
     "save_step": 25000,      // Number of training steps expected to plot training stats on TB and save model checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
+    "keep_best": false,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
     "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
     // DATA LOADING

--- a/TTS/vocoder/configs/multiband_melgan_config.json
+++ b/TTS/vocoder/configs/multiband_melgan_config.json
@@ -128,6 +128,8 @@
     "print_eval": false,     // If True, it prints loss values for each step in eval run.
     "save_step": 25000,      // Number of training steps expected to plot training stats on TB and save model checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
+    "keep_best": false,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
     "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
     // DATA LOADING

--- a/TTS/vocoder/configs/multiband_melgan_config.json
+++ b/TTS/vocoder/configs/multiband_melgan_config.json
@@ -128,8 +128,8 @@
     "print_eval": false,     // If True, it prints loss values for each step in eval run.
     "save_step": 25000,      // Number of training steps expected to plot training stats on TB and save model checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
-    "keep_best": false,  // If true, keeps all best_models after keep_after steps
-    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
+    "keep_all_best": false,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_all_best is true
     "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
     // DATA LOADING

--- a/TTS/vocoder/configs/multiband_melgan_config_mozilla.json
+++ b/TTS/vocoder/configs/multiband_melgan_config_mozilla.json
@@ -141,8 +141,8 @@
     "print_eval": false,     // If True, it prints loss values for each step in eval run.
     "save_step": 25000,      // Number of training steps expected to plot training stats on TB and save model checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
-    "keep_best": false,  // If true, keeps all best_models after keep_after steps
-    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
+    "keep_all_best": false,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_all_best is true
     "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
     // DATA LOADING

--- a/TTS/vocoder/configs/multiband_melgan_config_mozilla.json
+++ b/TTS/vocoder/configs/multiband_melgan_config_mozilla.json
@@ -141,6 +141,8 @@
     "print_eval": false,     // If True, it prints loss values for each step in eval run.
     "save_step": 25000,      // Number of training steps expected to plot training stats on TB and save model checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
+    "keep_best": false,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
     "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
     // DATA LOADING

--- a/TTS/vocoder/configs/parallel_wavegan_config.json
+++ b/TTS/vocoder/configs/parallel_wavegan_config.json
@@ -130,6 +130,8 @@
     "print_eval": false,     // If True, it prints loss values for each step in eval run.
     "save_step": 25000,      // Number of training steps expected to plot training stats on TB and save model checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
+    "keep_best": false,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
     "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
     // DATA LOADING

--- a/TTS/vocoder/configs/parallel_wavegan_config.json
+++ b/TTS/vocoder/configs/parallel_wavegan_config.json
@@ -130,8 +130,8 @@
     "print_eval": false,     // If True, it prints loss values for each step in eval run.
     "save_step": 25000,      // Number of training steps expected to plot training stats on TB and save model checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
-    "keep_best": false,  // If true, keeps all best_models after keep_after steps
-    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
+    "keep_all_best": false,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_all_best is true
     "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
     // DATA LOADING

--- a/TTS/vocoder/configs/universal_fullband_melgan.json
+++ b/TTS/vocoder/configs/universal_fullband_melgan.json
@@ -124,8 +124,8 @@
     "print_eval": false,     // If True, it prints loss values for each step in eval run.
     "save_step": 25000,      // Number of training steps expected to plot training stats on TB and save model checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
-    "keep_best": false,  // If true, keeps all best_models after keep_after steps
-    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
+    "keep_all_best": false,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_all_best is true
     "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
     // DATA LOADING

--- a/TTS/vocoder/configs/universal_fullband_melgan.json
+++ b/TTS/vocoder/configs/universal_fullband_melgan.json
@@ -124,6 +124,8 @@
     "print_eval": false,     // If True, it prints loss values for each step in eval run.
     "save_step": 25000,      // Number of training steps expected to plot training stats on TB and save model checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
+    "keep_best": false,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
     "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
     // DATA LOADING

--- a/TTS/vocoder/configs/wavegrad_libritts.json
+++ b/TTS/vocoder/configs/wavegrad_libritts.json
@@ -103,6 +103,8 @@
     "print_eval": false,     // If True, it prints loss values for each step in eval run.
     "save_step": 5000,      // Number of training steps expected to plot training stats on TB and save model checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
+    "keep_best": false,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
     "tb_model_param_stats": true,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
     // DATA LOADING

--- a/TTS/vocoder/configs/wavegrad_libritts.json
+++ b/TTS/vocoder/configs/wavegrad_libritts.json
@@ -103,8 +103,8 @@
     "print_eval": false,     // If True, it prints loss values for each step in eval run.
     "save_step": 5000,      // Number of training steps expected to plot training stats on TB and save model checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
-    "keep_best": false,  // If true, keeps all best_models after keep_after steps
-    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
+    "keep_all_best": false,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_all_best is true
     "tb_model_param_stats": true,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
     // DATA LOADING

--- a/TTS/vocoder/configs/wavernn_config.json
+++ b/TTS/vocoder/configs/wavernn_config.json
@@ -89,8 +89,8 @@
     "print_eval": false, // If True, it prints loss values for each step in eval run.
     "save_step": 25000, // Number of training steps expected to plot training stats on TB and save model checkpoints.
     "checkpoint": true, // If true, it saves checkpoints per "save_step"
-    "keep_best": false,  // If true, keeps all best_models after keep_after steps
-    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
+    "keep_all_best": false,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_all_best is true
     "tb_model_param_stats": false, // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
 // DATA LOADING

--- a/TTS/vocoder/configs/wavernn_config.json
+++ b/TTS/vocoder/configs/wavernn_config.json
@@ -89,6 +89,8 @@
     "print_eval": false, // If True, it prints loss values for each step in eval run.
     "save_step": 25000, // Number of training steps expected to plot training stats on TB and save model checkpoints.
     "checkpoint": true, // If true, it saves checkpoints per "save_step"
+    "keep_best": false,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
     "tb_model_param_stats": false, // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
 // DATA LOADING

--- a/TTS/vocoder/utils/io.py
+++ b/TTS/vocoder/utils/io.py
@@ -64,7 +64,7 @@ def save_checkpoint(model, optimizer, scheduler, model_disc, optimizer_disc,
 
 def save_best_model(current_loss, best_loss, model, optimizer, scheduler,
                     model_disc, optimizer_disc, scheduler_disc, current_step,
-                    epoch, out_path, keep_best=False, keep_after=10000,
+                    epoch, out_path, keep_all_best=False, keep_after=10000,
                     **kwargs):
     if current_loss < best_loss:
         best_model_name = f'best_model_{current_step}.pth.tar'
@@ -82,7 +82,7 @@ def save_best_model(current_loss, best_loss, model, optimizer, scheduler,
                    model_loss=current_loss,
                    **kwargs)
         # only delete previous if current is saved successfully
-        if not keep_best or (current_step < keep_after):
+        if not keep_all_best or (current_step < keep_after):
             model_names = glob.glob(
                 os.path.join(out_path, 'best_model*.pth.tar'))
             for model_name in model_names:

--- a/TTS/vocoder/utils/io.py
+++ b/TTS/vocoder/utils/io.py
@@ -1,4 +1,5 @@
 import os
+import glob
 import torch
 import datetime
 import pickle as pickle_tts
@@ -61,12 +62,13 @@ def save_checkpoint(model, optimizer, scheduler, model_disc, optimizer_disc,
                scheduler_disc, current_step, epoch, checkpoint_path, **kwargs)
 
 
-def save_best_model(target_loss, best_loss, model, optimizer, scheduler,
+def save_best_model(current_loss, best_loss, model, optimizer, scheduler,
                     model_disc, optimizer_disc, scheduler_disc, current_step,
-                    epoch, output_folder, **kwargs):
-    if target_loss < best_loss:
-        file_name = 'best_model.pth.tar'
-        checkpoint_path = os.path.join(output_folder, file_name)
+                    epoch, out_path, keep_best=False, keep_after=10000,
+                    **kwargs):
+    if current_loss < best_loss:
+        best_model_name = f'best_model_{current_step}.pth.tar'
+        checkpoint_path = os.path.join(out_path, best_model_name)
         print(" > BEST MODEL : {}".format(checkpoint_path))
         save_model(model,
                    optimizer,
@@ -77,7 +79,21 @@ def save_best_model(target_loss, best_loss, model, optimizer, scheduler,
                    current_step,
                    epoch,
                    checkpoint_path,
-                   model_loss=target_loss,
+                   model_loss=current_loss,
                    **kwargs)
-        best_loss = target_loss
+        # only delete previous if current is saved successfully
+        if not keep_best or (current_step < keep_after):
+            model_names = glob.glob(
+                os.path.join(out_path, 'best_model*.pth.tar'))
+            for model_name in model_names:
+                if os.path.basename(model_name) == best_model_name:
+                    continue
+                os.remove(model_name)
+        # create symlink to best model for convinience
+        link_name = 'best_model.pth.tar'
+        link_path = os.path.join(out_path, link_name)
+        if os.path.islink(link_path) or os.path.isfile(link_path):
+            os.remove(link_path)
+        os.symlink(best_model_name, os.path.join(out_path, link_name))
+        best_loss = current_loss
     return best_loss

--- a/tests/inputs/test_glow_tts.json
+++ b/tests/inputs/test_glow_tts.json
@@ -106,6 +106,8 @@
     "print_eval": false,     // If True, it prints intermediate loss values in evalulation.
     "save_step": 5000,      // Number of training steps expected to save traninpg stats and checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
+    "keep_best": true,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
     "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
     "apex_amp_level": null,
 

--- a/tests/inputs/test_glow_tts.json
+++ b/tests/inputs/test_glow_tts.json
@@ -106,8 +106,8 @@
     "print_eval": false,     // If True, it prints intermediate loss values in evalulation.
     "save_step": 5000,      // Number of training steps expected to save traninpg stats and checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
-    "keep_best": true,  // If true, keeps all best_models after keep_after steps
-    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
+    "keep_all_best": true,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_all_best is true
     "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
     "apex_amp_level": null,
 

--- a/tests/inputs/test_speedy_speech.json
+++ b/tests/inputs/test_speedy_speech.json
@@ -111,6 +111,8 @@
    "print_eval": false,     // If True, it prints intermediate loss values in evalulation.
    "save_step": 5000,      // Number of training steps expected to save traninpg stats and checkpoints.
    "checkpoint": true,     // If true, it saves checkpoints per "save_step"
+   "keep_best": true,  // If true, keeps all best_models after keep_after steps
+   "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
    "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.:set n
    "mixed_precision": false,
 

--- a/tests/inputs/test_speedy_speech.json
+++ b/tests/inputs/test_speedy_speech.json
@@ -111,8 +111,8 @@
    "print_eval": false,     // If True, it prints intermediate loss values in evalulation.
    "save_step": 5000,      // Number of training steps expected to save traninpg stats and checkpoints.
    "checkpoint": true,     // If true, it saves checkpoints per "save_step"
-   "keep_best": true,  // If true, keeps all best_models after keep_after steps
-   "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
+   "keep_all_best": true,  // If true, keeps all best_models after keep_after steps
+   "keep_after": 10000,    // Global step after which to keep best models if keep_all_best is true
    "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.:set n
    "mixed_precision": false,
 

--- a/tests/inputs/test_train_config.json
+++ b/tests/inputs/test_train_config.json
@@ -122,8 +122,8 @@
     "print_eval": false,     // If True, it prints intermediate loss values in evalulation.
     "save_step": 10000,      // Number of training steps expected to save traninpg stats and checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
-    "keep_best": true,  // If true, keeps all best_models after keep_after steps
-    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
+    "keep_all_best": true,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_all_best is true
     "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
     // DATA LOADING

--- a/tests/inputs/test_train_config.json
+++ b/tests/inputs/test_train_config.json
@@ -122,6 +122,8 @@
     "print_eval": false,     // If True, it prints intermediate loss values in evalulation.
     "save_step": 10000,      // Number of training steps expected to save traninpg stats and checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
+    "keep_best": true,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
     "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
     // DATA LOADING

--- a/tests/inputs/test_vocoder_multiband_melgan_config.json
+++ b/tests/inputs/test_vocoder_multiband_melgan_config.json
@@ -131,6 +131,8 @@
     "print_eval": false,     // If True, it prints loss values for each step in eval run.
     "save_step": 25000,      // Number of training steps expected to plot training stats on TB and save model checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
+    "keep_best": true,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
     "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
     // DATA LOADING

--- a/tests/inputs/test_vocoder_multiband_melgan_config.json
+++ b/tests/inputs/test_vocoder_multiband_melgan_config.json
@@ -131,8 +131,8 @@
     "print_eval": false,     // If True, it prints loss values for each step in eval run.
     "save_step": 25000,      // Number of training steps expected to plot training stats on TB and save model checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
-    "keep_best": true,  // If true, keeps all best_models after keep_after steps
-    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
+    "keep_all_best": true,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_all_best is true
     "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
     // DATA LOADING

--- a/tests/inputs/test_vocoder_wavegrad.json
+++ b/tests/inputs/test_vocoder_wavegrad.json
@@ -101,6 +101,8 @@
     "print_eval": false,     // If True, it prints loss values for each step in eval run.
     "save_step": 10000,      // Number of training steps expected to plot training stats on TB and save model checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
+    "keep_best": true,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
     "tb_model_param_stats": true,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
     // DATA LOADING

--- a/tests/inputs/test_vocoder_wavegrad.json
+++ b/tests/inputs/test_vocoder_wavegrad.json
@@ -101,8 +101,8 @@
     "print_eval": false,     // If True, it prints loss values for each step in eval run.
     "save_step": 10000,      // Number of training steps expected to plot training stats on TB and save model checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
-    "keep_best": true,  // If true, keeps all best_models after keep_after steps
-    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
+    "keep_all_best": true,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_all_best is true
     "tb_model_param_stats": true,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
     // DATA LOADING

--- a/tests/inputs/test_vocoder_wavernn_config.json
+++ b/tests/inputs/test_vocoder_wavernn_config.json
@@ -97,8 +97,8 @@
     "print_eval": false,     // If True, it prints loss values for each step in eval run.
     "save_step": 25000,      // Number of training steps expected to plot training stats on TB and save model checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
-    "keep_best": true,  // If true, keeps all best_models after keep_after steps
-    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
+    "keep_all_best": true,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_all_best is true
     "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
     // DATA LOADING

--- a/tests/inputs/test_vocoder_wavernn_config.json
+++ b/tests/inputs/test_vocoder_wavernn_config.json
@@ -97,6 +97,8 @@
     "print_eval": false,     // If True, it prints loss values for each step in eval run.
     "save_step": 25000,      // Number of training steps expected to plot training stats on TB and save model checkpoints.
     "checkpoint": true,     // If true, it saves checkpoints per "save_step"
+    "keep_best": true,  // If true, keeps all best_models after keep_after steps
+    "keep_after": 10000,    // Global step after which to keep best models if keep_best is true
     "tb_model_param_stats": false,     // true, plots param stats per layer on tensorboard. Might be memory consuming, but good for debugging.
 
     // DATA LOADING


### PR DESCRIPTION
Based on #643 this includes :
- best models names with a step stamp
- `best_model.pth.tar` symlink created for convinience
- saving multiple best models after a set step is available via `c.keep_best` and `c.keep_after`
- continuing training will find the checkpoint or the best model with the largest step stamp 
- when continuing training best loss is now taken from the latest best model