### PR TITLE
Updating models list to include EK1 TTS/vocoder

### DIFF
--- a/TTS/.models.json
+++ b/TTS/.models.json
@@ -1,6 +1,16 @@
 {
     "tts_models":{
         "en":{
+            "ek1":{
+                "tacotron2": {
+                    "description": "EK1 en-rp tacotron2 by NMStoker",
+                    "model_file": "1OJ5sLYmB03dQAf1FcY06b5X-0hiR0SNZ",
+                    "config_file": "1hSnodL--5AFJTWvlU96e0pCnCfNU3yM_",
+                    "stats_file": null,
+                    "default_vocoder": "vocoder_models/en/ek1/wavegrad",
+                    "commit": "c802255"
+                }
+            },
             "ljspeech":{
                 "glow-tts":{
                     "description": "",
@@ -70,6 +80,15 @@
             }
         },
         "en": {
+            "ek1":{
+                "wavegrad": {
+                    "description": "EK1 en-rp wavegrad by NMStoker",
+                    "model_file": "1ShaCSrQfSRjM66vo45Bgo019uJDDloLS",
+                    "config_file": "1otnQR5yTfN5A77yMKmUSzwh_VNvYwKai",
+                    "stats_file": null,
+                    "commit": "c802255"
+                }
+            },
             "ljspeech":{
                 "multiband-melgan":{
                     "model_file": "1Ty5DZdOc0F7OTGj9oJThYbL5iVu_2G0K",


### PR DESCRIPTION
I _think_ this should work to enable general users to download the EK1 TTS and vocoder models for their own use.  Works fine for me and I just updated from dev but would be great if someone else could verify it's good for them too.

I updated .models.json.  In my model config.json (on Google Drive) I also had to specifically add the "characters" field to ensure compatibility (hope I did that bit right too but it does seem to work now, was causing recent issues without it). I've stripped out the // comments (matching the other configs published this way) and also took out references to my local drive locations (just for neatness!)

Further EK1 details are here: [Discourse TTS community trained thread](https://discourse.mozilla.org/t/creating-a-github-page-for-hosting-community-trained-models/70889/11?u=nmstoker)

Hope this is useful! Of course, let me know if any of the fields / naming conventions or anything else need to change.

Neil