### PR TITLE
Fix: text is longer than the threshold

### DIFF
--- a/TTS/tts/datasets/TTSDataset.py
+++ b/TTS/tts/datasets/TTSDataset.py
@@ -160,7 +160,7 @@ class MyDataset(Dataset):
             # return a different sample if the phonemized
             # text is longer than the threshold
             # TODO: find a better fix
-            return self.load_data(100)
+            return self.load_data(len(self.items))
 
         sample = {
             'text': text,


### PR DESCRIPTION
instead of return self.load_data(100)), `return self.load_data(len(self.items))`